### PR TITLE
Add fhetch_replay.json data pipeline and nlohmann/json

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = vendor/openfhe
 	url = https://github.com/NiobiumInc/openfhe-development.git
 	branch = nb_main
+[submodule "vendor/json"]
+	path = vendor/json
+	url = https://github.com/nlohmann/json.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,9 @@ set(OPENFHE_INCLUDE_DIRS
 # OpenFHE library path
 set(OPENFHE_LIBRARY_PATH "${OPENFHE_INSTALL_DIR}/lib")
 
+# nlohmann/json (header-only, single_include)
+set(JSON_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/vendor/json/single_include")
+
 # OpenFHE libraries
 set(OPENFHE_LIBRARIES
     OPENFHEbinfhe
@@ -90,6 +93,7 @@ target_include_directories(niobium_client
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
         ${CMAKE_CURRENT_SOURCE_DIR}/src/fhetch_sim
+        ${JSON_INCLUDE_DIR}
 )
 
 # OpenFHE include paths — BUILD_INTERFACE only (not propagated to install tree;

--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,13 @@ help: ## Display this help message
 
 ##@ Submodules
 
-sync: sync-openfhe ## Sync all submodules to pinned commits
+sync: sync-openfhe sync-json ## Sync all submodules to pinned commits
 
 sync-openfhe: ## Sync OpenFHE submodule to pinned commit
 	git submodule update --init --recursive vendor/openfhe
+
+sync-json: ## Sync nlohmann/json submodule to pinned commit
+	git submodule update --init vendor/json
 
 update-openfhe: ## Update OpenFHE submodule to latest remote commit
 	cd $(OPENFHE_DIR) && git fetch origin && git checkout nb_main && git pull origin nb_main

--- a/include/niobium/compiler.h
+++ b/include/niobium/compiler.h
@@ -244,7 +244,21 @@ public:
         stop();
     }
 
+    // Internal: store captured input polynomial data for replay.
+    // Called by the tag_input template instantiation.
+    void store_input_element(const std::string& input_name,
+                             uint64_t addr_id, uint64_t modulus,
+                             const std::vector<uint64_t>& values);
+
+    // Internal: store output probe address for replay.
+    // Called by the probe template instantiation.
+    void store_output_probe(const std::string& output_name,
+                            uint64_t addr_id, uint64_t modulus);
+
 private:
+    void write_replay_json();
+    void write_replay_outputs();
+
     struct Impl;
     std::unique_ptr<Impl> impl_;
 

--- a/src/auto_facade.cpp
+++ b/src/auto_facade.cpp
@@ -103,12 +103,13 @@ void openfhe_cprobe_save_dcrt_poly(const void* /*dcrt_poly_ptr*/) {
 // Explicit template instantiations for Compiler methods with OpenFHE types
 // ============================================================================
 
+#include "compiler_internal.h"
+
 namespace niobium {
 
 template<>
 void Compiler::capture_crypto_context<lbcrypto::CryptoContext<DCRTPoly>>(
     const lbcrypto::CryptoContext<DCRTPoly>& cc) {
-    // Store ring dimension for the simulator.
     uint64_t rd = cc->GetRingDimension();
     set_ring_dimension(rd);
     std::cout << "[NIOBIUM] Captured crypto context: ring_dim=" << rd << std::endl;
@@ -116,25 +117,53 @@ void Compiler::capture_crypto_context<lbcrypto::CryptoContext<DCRTPoly>>(
 
 template<>
 void Compiler::tag_input<lbcrypto::Ciphertext<DCRTPoly>>(
-    const std::string& /*input_name*/,
-    lbcrypto::Ciphertext<DCRTPoly>& /*value*/,
+    const std::string& input_name,
+    lbcrypto::Ciphertext<DCRTPoly>& ct,
     std::optional<std::filesystem::path> /*file*/) {
-    // Input tagging is recorded via the probe mechanism.
+    // Extract polynomial data from the ciphertext and store for replay.
+    const auto& elements = ct->GetElements();
+    for (const auto& dcrt : elements) {
+        for (const auto& poly : dcrt.GetAllElements()) {
+            uintptr_t poly_id = poly.GetId();
+            uint64_t fhetch_addr = detail::lookup_fhetch_address(poly_id);
+            if (fhetch_addr == static_cast<uint64_t>(-1)) continue;
+
+            uint64_t modulus = poly.GetModulus().ConvertToInt();
+            size_t n = poly.GetLength();
+            std::vector<uint64_t> vals(n);
+            const auto& vec = poly.GetValues();
+            for (size_t i = 0; i < n; ++i)
+                vals[i] = vec[i].ConvertToInt();
+
+            store_input_element(input_name, fhetch_addr, modulus, vals);
+        }
+    }
 }
 
 template<>
 void Compiler::tag_input<lbcrypto::Ciphertext<DCRTPoly>>(
-    const std::string& /*input_name*/,
-    const lbcrypto::Ciphertext<DCRTPoly>& /*value*/,
-    std::optional<std::filesystem::path> /*file*/) {
-    // Const overload.
+    const std::string& input_name,
+    const lbcrypto::Ciphertext<DCRTPoly>& ct,
+    std::optional<std::filesystem::path> file) {
+    auto& mutable_ct = const_cast<lbcrypto::Ciphertext<DCRTPoly>&>(ct);
+    tag_input(input_name, mutable_ct, file);
 }
 
 template<>
 void Compiler::probe<lbcrypto::Ciphertext<DCRTPoly>>(
-    const std::string& /*var_name*/,
-    const lbcrypto::Ciphertext<DCRTPoly>& /*value*/) {
-    // Output probing is recorded via the probe mechanism.
+    const std::string& var_name,
+    const lbcrypto::Ciphertext<DCRTPoly>& ct) {
+    // Record the FHETCH addresses of the output polynomials.
+    const auto& elements = ct->GetElements();
+    for (const auto& dcrt : elements) {
+        for (const auto& poly : dcrt.GetAllElements()) {
+            uintptr_t poly_id = poly.GetId();
+            uint64_t fhetch_addr = detail::lookup_fhetch_address(poly_id);
+            if (fhetch_addr == static_cast<uint64_t>(-1)) continue;
+            uint64_t modulus = poly.GetModulus().ConvertToInt();
+            store_output_probe(var_name, fhetch_addr, modulus);
+        }
+    }
 }
 
 }  // namespace niobium

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -5,8 +5,12 @@
 #include "niobium/fhetch_sim/simulator.h"
 #include "trace_writer.h"
 
+#include <nlohmann/json.hpp>
+
+#include <chrono>
 #include <cstring>
 #include <filesystem>
+#include <fstream>
 #include <functional>
 #include <iostream>
 #include <map>
@@ -48,12 +52,34 @@ struct Compiler::Impl {
 
     // Crypto context info
     uint64_t ring_dimension = 0;
+    std::vector<uint64_t> modulus_chain;
 
     // Last written trace path (set by stop())
     std::filesystem::path last_trace_path;
 
     // Simulator instance (created by replay())
     std::unique_ptr<fhetch_sim::Simulator> simulator;
+
+    // Input polynomial data captured by tag_input().
+    // Each entry: {name, [{addr_id, modulus, values}]}
+    struct PolyElement {
+        uint64_t addr_id;
+        uint64_t modulus;
+        std::vector<uint64_t> values;
+    };
+    struct InputRecord {
+        std::string name;
+        std::vector<PolyElement> elements;
+    };
+    std::vector<InputRecord> captured_inputs;
+
+    // Output probe addresses captured by probe().
+    struct OutputRecord {
+        std::string name;
+        std::vector<uint64_t> addr_ids;
+        std::vector<uint64_t> moduli;
+    };
+    std::vector<OutputRecord> captured_outputs;
 
     // Derived program directory
     std::filesystem::path program_dir;
@@ -126,11 +152,8 @@ bool Compiler::stop() {
     auto dir = get_program_directory();
     impl_->last_trace_path = impl_->trace_writer.write(dir, impl_->full_program_name());
 
-    // Save FHETCH input/output metadata if in FHETCH mode
-    if (impl_->fhetch_mode) {
-        // These are called from fhetch_api.cpp's save functions
-        // which the user or the compiler triggers.
-    }
+    // Write fhetch_replay.json with inputs, outputs, and modulus table
+    write_replay_json();
 
     std::cout << "[NIOBIUM] Recording stopped ("
               << impl_->trace_writer.instruction_count()
@@ -200,6 +223,38 @@ bool Compiler::is_cache_valid() {
 
 void Compiler::set_ring_dimension(uint64_t N) {
     impl_->ring_dimension = N;
+}
+
+void Compiler::store_input_element(const std::string& input_name,
+                                   uint64_t addr_id, uint64_t modulus,
+                                   const std::vector<uint64_t>& values) {
+    // Append to existing InputRecord or create a new one
+    for (auto& rec : impl_->captured_inputs) {
+        if (rec.name == input_name) {
+            rec.elements.push_back({addr_id, modulus, values});
+            return;
+        }
+    }
+    Impl::InputRecord rec;
+    rec.name = input_name;
+    rec.elements.push_back({addr_id, modulus, values});
+    impl_->captured_inputs.push_back(std::move(rec));
+}
+
+void Compiler::store_output_probe(const std::string& output_name,
+                                  uint64_t addr_id, uint64_t modulus) {
+    for (auto& rec : impl_->captured_outputs) {
+        if (rec.name == output_name) {
+            rec.addr_ids.push_back(addr_id);
+            rec.moduli.push_back(modulus);
+            return;
+        }
+    }
+    Impl::OutputRecord rec;
+    rec.name = output_name;
+    rec.addr_ids.push_back(addr_id);
+    rec.moduli.push_back(modulus);
+    impl_->captured_outputs.push_back(std::move(rec));
 }
 
 void Compiler::enable_hollow_mode(bool enabled) {
@@ -299,6 +354,17 @@ bool Compiler::replay() {
         return false;
     }
 
+    // Populate simulator memory from captured input data
+    for (const auto& input : impl_->captured_inputs) {
+        for (const auto& elem : input.elements) {
+            impl_->simulator->store_polynomial(elem.addr_id, elem.values, elem.modulus);
+        }
+    }
+    if (!impl_->captured_inputs.empty()) {
+        std::cout << "[NIOBIUM] Loaded " << impl_->captured_inputs.size()
+                  << " inputs into simulator memory" << std::endl;
+    }
+
     auto result = impl_->simulator->run();
 
     if (result.errors > 0) {
@@ -308,7 +374,116 @@ bool Compiler::replay() {
 
     std::cout << "[NIOBIUM] Replay complete: " << result.instructions_executed
               << " instructions, " << result.elapsed_seconds << "s" << std::endl;
+
+    // Write output polynomial values for probe addresses
+    write_replay_outputs();
+
     return true;
+}
+
+// ============================================================================
+// write_replay_json — serialize inputs, outputs, and metadata for replay
+// ============================================================================
+
+void Compiler::write_replay_json() {
+    using json = nlohmann::json;
+    auto dir = get_program_directory();
+    auto path = dir / "fhetch_replay.json";
+
+    json replay;
+    replay["program_name"] = impl_->full_program_name();
+    replay["ring_dimension"] = impl_->ring_dimension;
+    replay["trace_file"] = impl_->last_trace_path.filename().string();
+
+    // Per-input files
+    json inputs_arr = json::array();
+    for (const auto& input : impl_->captured_inputs) {
+        std::string input_file = impl_->full_program_name() + ".input_" + input.name + ".json";
+
+        json idx;
+        idx["name"] = input.name;
+        idx["file"] = input_file;
+        idx["element_count"] = input.elements.size();
+        inputs_arr.push_back(idx);
+
+        // Write per-input data file
+        json input_data;
+        input_data["name"] = input.name;
+        json elems_arr = json::array();
+        for (const auto& e : input.elements) {
+            json elem;
+            elem["addr_id"] = e.addr_id;
+            elem["modulus"] = e.modulus;
+            elem["values"] = e.values;
+            elems_arr.push_back(elem);
+        }
+        input_data["elements"] = elems_arr;
+
+        std::ofstream inp(dir / input_file);
+        if (inp.is_open()) {
+            inp << input_data.dump(2) << std::endl;
+            inp.close();
+        }
+    }
+    replay["inputs"] = inputs_arr;
+
+    // Output probe definitions
+    json outputs_arr = json::array();
+    for (const auto& output : impl_->captured_outputs) {
+        json out_entry;
+        out_entry["name"] = output.name;
+        out_entry["addr_ids"] = output.addr_ids;
+        out_entry["moduli"] = output.moduli;
+        outputs_arr.push_back(out_entry);
+    }
+    replay["outputs"] = outputs_arr;
+
+    std::ofstream out(path);
+    if (out.is_open()) {
+        out << replay.dump(2) << std::endl;
+        out.close();
+        std::cout << "[NIOBIUM] Replay JSON written: " << path << std::endl;
+    }
+}
+
+// ============================================================================
+// write_replay_outputs — after simulation, write computed probe values
+// ============================================================================
+
+void Compiler::write_replay_outputs() {
+    using json = nlohmann::json;
+    if (!impl_->simulator || impl_->captured_outputs.empty()) return;
+
+    auto dir = get_program_directory();
+    auto path = dir / "fhetch_replay_outputs.json";
+
+    json root;
+    json outputs_arr = json::array();
+    for (const auto& output : impl_->captured_outputs) {
+        json out_entry;
+        out_entry["name"] = output.name;
+        json elems_arr = json::array();
+        for (size_t j = 0; j < output.addr_ids.size(); ++j) {
+            uint64_t addr = output.addr_ids[j];
+            auto values = impl_->simulator->get_polynomial(addr);
+            json elem;
+            elem["addr_id"] = addr;
+            elem["modulus"] = output.moduli[j];
+            elem["status"] = values.empty() ? "missing" : "computed";
+            elem["values"] = values;
+            elems_arr.push_back(elem);
+        }
+        out_entry["elements"] = elems_arr;
+        outputs_arr.push_back(out_entry);
+    }
+    root["outputs"] = outputs_arr;
+
+    std::ofstream out(path);
+    if (out.is_open()) {
+        out << root.dump(2) << std::endl;
+        out.close();
+        std::cout << "[NIOBIUM] Replay outputs written: " << path << std::endl;
+    }
 }
 
 // ============================================================================

--- a/src/compiler_internal.h
+++ b/src/compiler_internal.h
@@ -8,10 +8,15 @@
 #pragma once
 
 #include "trace_writer.h"
+#include <cstdint>
 
 namespace niobium::detail {
 
 /// Get the global TraceWriter instance (owned by the Compiler singleton).
 TraceWriter& trace_writer();
+
+/// Look up the FHETCH address for an OpenFHE polynomial ID.
+/// Returns (uint64_t)-1 if not found.
+uint64_t lookup_fhetch_address(uintptr_t openfhe_poly_id);
 
 }  // namespace niobium::detail

--- a/src/probes.cpp
+++ b/src/probes.cpp
@@ -305,3 +305,18 @@ void openfhe_cprobe_switchmodulus(uintptr_t dst, uintptr_t src,
 }
 
 }  // extern "C"
+
+// ============================================================================
+// Internal helper: look up FHETCH address for an OpenFHE poly ID
+// ============================================================================
+
+namespace niobium::detail {
+
+uint64_t lookup_fhetch_address(uintptr_t openfhe_poly_id) {
+    std::lock_guard<std::mutex> lock(g_probe_mutex);
+    auto it = g_address_map.find(openfhe_poly_id);
+    if (it != g_address_map.end()) return it->second;
+    return static_cast<uint64_t>(-1);
+}
+
+}  // namespace niobium::detail


### PR DESCRIPTION
## Summary

- **fhetch_replay.json** written by `stop()` — catalogs inputs, outputs, and program metadata for the FHETCH simulator
- **Per-input JSON files** with polynomial coefficient data extracted from OpenFHE ciphertexts (`{addr_id, modulus, values[N]}`)
- **fhetch_replay_outputs.json** written after `replay()` — computed polynomial values at probe addresses
- **nlohmann/json v3.11.3** added as `vendor/json` submodule (same library used by niobium-compiler)
- **Input data capture**: `tag_input<Ciphertext>` extracts NativePoly coefficients, maps OpenFHE poly IDs to FHETCH addresses
- **Output probe capture**: `probe<Ciphertext>` records output addr_ids for post-simulation retrieval

## File layout after recording + replay

```
program_dir/
  program.fhetch                    # Instruction trace (modulus table + ops)
  fhetch_replay.json                # Master manifest (inputs, outputs, metadata)
  program.input_ct_a.json           # Per-input polynomial data
  program.input_ct_b.json
  fhetch_replay_outputs.json        # Computed probe values after simulation
```

## Known limitation

Simulator outputs are currently zero for workloads using evaluation keys because key polynomial data is not yet captured into the simulator. Input ciphertext data is correctly captured and populated.

## Test plan

- [ ] `make sync` — sync submodules (includes new `vendor/json`)
- [ ] `make release` — full build
- [ ] `make test-mult-release` — verify fhetch_replay.json + input files are written

🤖 Generated with [Claude Code](https://claude.com/claude-code)