### PR TITLE
Switch to CKKS, add explicit copy/zero probes, uninitialized read warnings

### DIFF
--- a/examples/mult/client.cpp
+++ b/examples/mult/client.cpp
@@ -1,13 +1,13 @@
 // Copyright 2024-present Niobium Microsystems, Inc.
 // Licensed under the Apache License, Version 2.0.
 //
-// Multiply example — client side
+// Multiply example — client side (CKKS)
 //
-// Generates a BFV crypto context, keys, and encrypts two integers.
+// Generates a CKKS crypto context, keys, and encrypts two values.
 // All artifacts are serialized to a directory for the server to consume.
 //
 // Usage: ./mult_client [output_dir [a b]]
-//   Defaults: output_dir=mult_keys, a=7, b=13
+//   Defaults: output_dir=mult_keys, a=7.0, b=13.0
 
 #include "openfhe.h"
 
@@ -16,28 +16,31 @@
 #include "ciphertext-ser.h"
 #include "cryptocontext-ser.h"
 #include "key/key-ser.h"
-#include "scheme/bfvrns/bfvrns-ser.h"
+#include "scheme/ckksrns/ckksrns-ser.h"
 
 using namespace lbcrypto;
 
 int main(int argc, char* argv[]) {
     std::string outputDir = "mult_keys";
-    int64_t a = 7, b = 13;
+    double a = 7.0, b = 13.0;
 
     if (argc > 1) outputDir = argv[1];
-    if (argc > 2) a = std::stoll(argv[2]);
-    if (argc > 3) b = std::stoll(argv[3]);
+    if (argc > 2) a = std::stod(argv[2]);
+    if (argc > 3) b = std::stod(argv[3]);
 
-    std::cout << "=== Integer Multiply — Client (Key Generation) ===" << std::endl;
+    std::cout << "=== CKKS Multiply — Client (Key Generation) ===" << std::endl;
     std::cout << "Output directory: " << outputDir << std::endl;
     std::cout << "a = " << a << ", b = " << b << std::endl;
 
     std::filesystem::create_directories(outputDir);
 
-    // ---- BFV parameters ----
-    CCParams<CryptoContextBFVRNS> parameters;
-    parameters.SetPlaintextModulus(65537);
-    parameters.SetMultiplicativeDepth(1);
+    // ---- CKKS parameters ----
+    CCParams<CryptoContextCKKSRNS> parameters;
+    parameters.SetSecurityLevel(HEStd_NotSet);
+    parameters.SetRingDim(2048);
+    parameters.SetMultiplicativeDepth(2);
+    parameters.SetScalingModSize(50);
+    parameters.SetScalingTechnique(FLEXIBLEAUTO);
 
     CryptoContext<DCRTPoly> cc = GenCryptoContext(parameters);
     cc->Enable(PKE);
@@ -51,41 +54,31 @@ int main(int argc, char* argv[]) {
     cc->EvalMultKeyGen(keyPair.secretKey);
 
     // ---- Serialize crypto context + keys ----
-    if (!Serial::SerializeToFile(outputDir + "/cc.bin", cc, SerType::BINARY)) {
-        std::cerr << "Error: Failed to serialize crypto context" << std::endl;
-        return 1;
-    }
-    if (!Serial::SerializeToFile(outputDir + "/pk.bin", keyPair.publicKey, SerType::BINARY)) {
-        std::cerr << "Error: Failed to serialize public key" << std::endl;
-        return 1;
-    }
-    if (!Serial::SerializeToFile(outputDir + "/sk.bin", keyPair.secretKey, SerType::BINARY)) {
-        std::cerr << "Error: Failed to serialize secret key" << std::endl;
-        return 1;
-    }
+    if (!Serial::SerializeToFile(outputDir + "/cc.bin", cc, SerType::BINARY))
+        throw std::runtime_error("Failed to serialize crypto context");
+    if (!Serial::SerializeToFile(outputDir + "/pk.bin", keyPair.publicKey, SerType::BINARY))
+        throw std::runtime_error("Failed to serialize public key");
+    if (!Serial::SerializeToFile(outputDir + "/sk.bin", keyPair.secretKey, SerType::BINARY))
+        throw std::runtime_error("Failed to serialize secret key");
 
     std::ofstream mkStream(outputDir + "/mk.bin", std::ios::out | std::ios::binary);
-    if (!mkStream.is_open() || !cc->SerializeEvalMultKey(mkStream, SerType::BINARY)) {
-        std::cerr << "Error: Failed to serialize eval mult key" << std::endl;
-        return 1;
-    }
+    if (!mkStream.is_open() || !cc->SerializeEvalMultKey(mkStream, SerType::BINARY))
+        throw std::runtime_error("Failed to serialize eval mult key");
     mkStream.close();
 
     // ---- Encrypt inputs ----
-    Plaintext pt_a = cc->MakePackedPlaintext({a});
-    Plaintext pt_b = cc->MakePackedPlaintext({b});
+    std::vector<double> va = {a};
+    std::vector<double> vb = {b};
+    auto pt_a = cc->MakeCKKSPackedPlaintext(va);
+    auto pt_b = cc->MakeCKKSPackedPlaintext(vb);
 
     auto ct_a = cc->Encrypt(keyPair.publicKey, pt_a);
     auto ct_b = cc->Encrypt(keyPair.publicKey, pt_b);
 
-    if (!Serial::SerializeToFile(outputDir + "/ct_a.bin", ct_a, SerType::BINARY)) {
-        std::cerr << "Error: Failed to serialize ciphertext a" << std::endl;
-        return 1;
-    }
-    if (!Serial::SerializeToFile(outputDir + "/ct_b.bin", ct_b, SerType::BINARY)) {
-        std::cerr << "Error: Failed to serialize ciphertext b" << std::endl;
-        return 1;
-    }
+    if (!Serial::SerializeToFile(outputDir + "/ct_a.bin", ct_a, SerType::BINARY))
+        throw std::runtime_error("Failed to serialize ciphertext a");
+    if (!Serial::SerializeToFile(outputDir + "/ct_b.bin", ct_b, SerType::BINARY))
+        throw std::runtime_error("Failed to serialize ciphertext b");
 
     // Save plaintext values for verification
     std::ofstream valStream(outputDir + "/values.txt");

--- a/examples/mult/decrypt.cpp
+++ b/examples/mult/decrypt.cpp
@@ -1,19 +1,21 @@
 // Copyright 2024-present Niobium Microsystems, Inc.
 // Licensed under the Apache License, Version 2.0.
 //
-// Multiply example — decrypt and verify
+// Multiply example — decrypt and verify (CKKS)
 //
-// Loads the BFV crypto context, secret key, and result ciphertext
+// Loads the CKKS crypto context, secret key, and result ciphertext
 // produced by the server. Decrypts and verifies a*b.
 //
 // Usage: ./mult_decrypt [key_dir]
 
 #include "openfhe.h"
 
+#include <cmath>
+
 #include "ciphertext-ser.h"
 #include "cryptocontext-ser.h"
 #include "key/key-ser.h"
-#include "scheme/bfvrns/bfvrns-ser.h"
+#include "scheme/ckksrns/ckksrns-ser.h"
 
 using namespace lbcrypto;
 
@@ -21,7 +23,7 @@ int main(int argc, char* argv[]) {
     std::string keyDir = "mult_keys";
     if (argc > 1) keyDir = argv[1];
 
-    std::cout << "=== Integer Multiply — Decrypt & Verify ===" << std::endl;
+    std::cout << "=== CKKS Multiply — Decrypt & Verify ===" << std::endl;
     std::cout << "Loading from: " << keyDir << std::endl;
 
     // ---- Load crypto context ----
@@ -40,7 +42,7 @@ int main(int argc, char* argv[]) {
         throw std::runtime_error("Failed to load result ciphertext");
 
     // ---- Load expected values ----
-    int64_t a = 0, b = 0;
+    double a = 0, b = 0;
     {
         std::ifstream valStream(keyDir + "/values.txt");
         if (!valStream.is_open())
@@ -53,16 +55,20 @@ int main(int argc, char* argv[]) {
     cc->Decrypt(secretKey, ct_result, &pt_result);
     pt_result->SetLength(1);
 
-    int64_t result = pt_result->GetPackedValue()[0];
-    int64_t expected = 2 * a + b;
+    double result = pt_result->GetRealPackedValue()[0];
+    double expected = a * b;
+    double tolerance = 0.01;
+    double diff = std::abs(result - expected);
 
-    std::cout << "Result: 2*" << a << " + " << b << " = " << result << std::endl;
+    std::cout << "Result: " << a << " * " << b << " = " << result
+              << " (expected " << expected << ", diff " << diff << ")" << std::endl;
 
-    if (result == expected) {
-        std::cout << "[PASS] " << result << " == " << expected << std::endl;
+    if (diff < tolerance) {
+        std::cout << "[PASS] " << result << " ~= " << expected << std::endl;
         return 0;
     } else {
-        std::cerr << "[FAIL] " << result << " != " << expected << std::endl;
+        std::cerr << "[FAIL] " << result << " != " << expected
+                  << " (diff " << diff << " > " << tolerance << ")" << std::endl;
         return 1;
     }
 }

--- a/examples/mult/server.cpp
+++ b/examples/mult/server.cpp
@@ -1,12 +1,12 @@
 // Copyright 2024-present Niobium Microsystems, Inc.
 // Licensed under the Apache License, Version 2.0.
 //
-// Multiply example — server side
+// Multiply example — server side (CKKS)
 //
-// Loads BFV crypto context, keys, and two encrypted integers from client.
-// Records a*b via the Niobium compiler using hollow mode, producing a
-// FHETCH instruction trace. Then replays the trace through the FHETCH
-// simulator to execute the computation using OpenFHE modular arithmetic.
+// Loads CKKS crypto context, keys, and two encrypted values from client.
+// Records a*b via the Niobium compiler, producing a FHETCH instruction trace.
+// Then replays the trace through the FHETCH simulator and serializes the
+// result ciphertext for the decrypt step.
 //
 // Usage: ./mult_server [key_dir]
 
@@ -16,7 +16,7 @@
 #include "ciphertext-ser.h"
 #include "cryptocontext-ser.h"
 #include "key/key-ser.h"
-#include "scheme/bfvrns/bfvrns-ser.h"
+#include "scheme/ckksrns/ckksrns-ser.h"
 
 using namespace lbcrypto;
 
@@ -24,11 +24,11 @@ int main(int argc, char* argv[]) {
     // ---- Niobium compiler setup ----
     niobium::compiler().init(argc, argv);
     niobium::compiler().set_program_info(
-        "mult_server", "1.0", "BFV integer multiplication — FHETCH trace");
+        "mult_server", "1.0", "CKKS multiplication — FHETCH trace");
     niobium::compiler().set_build_info(__FILE__, __LINE__, __TIMESTAMP__);
 
     niobium::Compiler::CacheParameters params;
-    params.push_back({"workload", "bfv_mult"});
+    params.push_back({"workload", "ckks_mult"});
     niobium::compiler().cache_parameters(params);
 
     std::string keyDir = "mult_keys";
@@ -37,7 +37,7 @@ int main(int argc, char* argv[]) {
         if (arg.find("--") != 0) { keyDir = arg; break; }
     }
 
-    std::cout << "=== Integer Multiply — Server ===" << std::endl;
+    std::cout << "=== CKKS Multiply — Server ===" << std::endl;
     std::cout << "Loading from: " << keyDir << std::endl;
 
     // ---- Load crypto context ----
@@ -47,6 +47,16 @@ int main(int argc, char* argv[]) {
 
     std::cout << "Ring dimension: " << cc->GetRingDimension() << std::endl;
 
+    // ---- Load keys ----
+    {
+        std::ifstream mkStream(keyDir + "/mk.bin", std::ios::in | std::ios::binary);
+        if (mkStream.is_open()) {
+            if (!cc->DeserializeEvalMultKey(mkStream, SerType::BINARY))
+                throw std::runtime_error("Failed to load eval mult key");
+            std::cout << "Loaded eval mult key" << std::endl;
+        }
+    }
+
     // ---- Load ciphertexts ----
     Ciphertext<DCRTPoly> ct_a, ct_b;
     if (!Serial::DeserializeFromFile(keyDir + "/ct_a.bin", ct_a, SerType::BINARY))
@@ -54,20 +64,20 @@ int main(int argc, char* argv[]) {
     if (!Serial::DeserializeFromFile(keyDir + "/ct_b.bin", ct_b, SerType::BINARY))
         throw std::runtime_error("Failed to load ciphertext b");
 
-    // ---- Capture crypto context ----
+    // ---- Capture crypto context and keys for simulator ----
     niobium::compiler().capture_crypto_context(cc);
+    niobium::compiler().tag_keys(cc);
 
-    // ---- Tag inputs (before start, following compiler convention) ----
+    // ---- Tag inputs ----
     niobium::compiler().tag_input("ct_a", ct_a);
     niobium::compiler().tag_input("ct_b", ct_b);
 
     if (!niobium::compiler().is_cache_valid()) {
         // ---- RECORDING PHASE ----
-        std::cout << "\n--- Recording EvalAdd(a,b) + EvalAdd(result,a) ---" << std::endl;
+        std::cout << "\n--- Recording EvalMult ---" << std::endl;
         niobium::compiler().start();
 
-        auto ct_tmp = cc->EvalAdd(ct_a, ct_b);     // a + b
-        auto ct_result = cc->EvalAdd(ct_tmp, ct_a); // (a + b) + a = 2a + b
+        auto ct_result = cc->EvalMult(ct_a, ct_b);
 
         niobium::compiler().probe("result", ct_result);
         niobium::compiler().stop();

--- a/include/niobium/compiler.h
+++ b/include/niobium/compiler.h
@@ -219,10 +219,13 @@ public:
                 CiphertextType& result);
 
     /// Reconstruct probe ciphertexts from simulator output.
-    /// Called internally after replay(). Loads ciphertext templates,
-    /// fills polynomial values from the simulator, and serializes
-    /// to serialized_probes/<name>.ct.
     void reconstruct_probes();
+
+    /// Re-extract polynomial data from all stored OpenFHE objects.
+    /// Called at replay() time to capture polynomials at their current
+    /// FHETCH addresses, including derived addresses created by OpenFHE's
+    /// internal processing between tag_input/tag_keys and start().
+    void refresh_all_inputs();
 
     // ====================================================================
     // FUNCTIONAL EPOCHS
@@ -268,6 +271,9 @@ public:
         std::forward<Lambda>(work)(std::forward<Args>(args)...);
         stop();
     }
+
+    /// Clear all captured input data (called before refresh).
+    void clear_captured_inputs();
 
     // Internal: store captured input polynomial data for replay.
     // Called by the tag_input template instantiation.

--- a/src/auto_facade.cpp
+++ b/src/auto_facade.cpp
@@ -26,8 +26,18 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <vector>
 
 using DCRTPoly = lbcrypto::DCRTPoly;
+
+// ============================================================================
+// Stored references to OpenFHE objects for re-extraction at replay() time.
+// The fhetch_driver approach: capture ALL polynomial data right before
+// simulation, including derived addresses from OpenFHE's pre-processing.
+// ============================================================================
+
+static std::vector<lbcrypto::Ciphertext<DCRTPoly>> g_stored_ciphertexts;
+static lbcrypto::CryptoContext<DCRTPoly> g_stored_cc;
 
 // ============================================================================
 // Global flags read by instrumented OpenFHE headers
@@ -141,6 +151,9 @@ void Compiler::capture_crypto_context<lbcrypto::CryptoContext<DCRTPoly>>(
 
     set_crypto_context_info(scheme, depth, 0, "HEStd_NotSet", modulus_chain);
 
+    // Store for re-extraction at replay() time
+    g_stored_cc = cc;
+
     std::cout << "[NIOBIUM] Captured crypto context: scheme=" << scheme
               << " ring_dim=" << rd
               << " depth=" << depth
@@ -205,6 +218,9 @@ void Compiler::tag_input<lbcrypto::Ciphertext<DCRTPoly>>(
             }
         }
     }
+
+    // Store reference for re-extraction at replay() time
+    g_stored_ciphertexts.push_back(ct);
 }
 
 template<>
@@ -345,6 +361,84 @@ void Compiler::tag_keys<lbcrypto::CryptoContext<DCRTPoly>>(
     } catch (...) {}
 
     std::cout << "[NIOBIUM] Tagged " << total << " key polynomials for replay" << std::endl;
+}
+
+// ============================================================================
+// refresh_all_inputs() — re-extract ALL polynomial data at replay() time
+// ============================================================================
+// This is the fhetch_driver approach: walk all stored OpenFHE objects
+// (ciphertexts + keys) and capture their polynomial data at whatever
+// FHETCH addresses their current poly IDs map to. This captures
+// derived addresses created by OpenFHE's pre-processing.
+
+static size_t extract_all_polys_from_dcrt(niobium::Compiler& compiler,
+                                          const std::string& name,
+                                          const std::vector<DCRTPoly>& dcrts) {
+    size_t count = 0;
+    for (const auto& dcrt : dcrts) {
+        for (const auto& poly : dcrt.GetAllElements()) {
+            uintptr_t poly_id = poly.GetId();
+            uint64_t fhetch_addr = niobium::detail::lookup_fhetch_address(poly_id);
+            if (fhetch_addr == static_cast<uint64_t>(-1)) continue;
+
+            uint64_t modulus = poly.GetModulus().ConvertToInt();
+            size_t n = poly.GetLength();
+            std::vector<uint64_t> vals(n);
+            const auto& vec = poly.GetValues();
+            for (size_t i = 0; i < n; ++i)
+                vals[i] = vec[i].ConvertToInt();
+
+            compiler.store_input_element(name, fhetch_addr, modulus, vals);
+            count++;
+        }
+    }
+    return count;
+}
+
+void niobium::Compiler::refresh_all_inputs() {
+    // Clear previously captured inputs — we're re-capturing everything
+    // from the live OpenFHE objects at their current state.
+    clear_captured_inputs();
+
+    size_t total = 0;
+
+    // Re-extract from stored ciphertexts
+    for (size_t i = 0; i < g_stored_ciphertexts.size(); ++i) {
+        const auto& ct = g_stored_ciphertexts[i];
+        if (!ct) continue;
+        total += extract_all_polys_from_dcrt(*this, "ct_" + std::to_string(i),
+                                             ct->GetElements());
+    }
+
+    // Re-extract from ALL EvalMult keys
+    try {
+        const auto& allMultKeys = lbcrypto::CryptoContextImpl<DCRTPoly>::GetAllEvalMultKeys();
+        for (const auto& [keyTag, keyVec] : allMultKeys) {
+            for (const auto& evalKey : keyVec) {
+                total += extract_all_polys_from_dcrt(*this, "evalmult_key",
+                             evalKey->GetAVector());
+                total += extract_all_polys_from_dcrt(*this, "evalmult_key",
+                             evalKey->GetBVector());
+            }
+        }
+    } catch (...) {}
+
+    // Re-extract from ALL EvalAutomorphism keys
+    try {
+        const auto& allAutoKeys = lbcrypto::CryptoContextImpl<DCRTPoly>::GetAllEvalAutomorphismKeys();
+        for (const auto& [keyTag, keyMap] : allAutoKeys) {
+            if (!keyMap) continue;
+            for (const auto& [idx, evalKey] : *keyMap) {
+                total += extract_all_polys_from_dcrt(*this, "automorphism_key",
+                             evalKey->GetAVector());
+                total += extract_all_polys_from_dcrt(*this, "automorphism_key",
+                             evalKey->GetBVector());
+            }
+        }
+    } catch (...) {}
+
+    std::cout << "[NIOBIUM] Refreshed " << total
+              << " polynomials from live OpenFHE objects" << std::endl;
 }
 
 // ============================================================================

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -267,6 +267,10 @@ void Compiler::set_key_start_addr_id(const std::string& key_type, uint64_t addr_
         impl_->evalautomorphism_start_addr_id = addr_id;
 }
 
+void Compiler::clear_captured_inputs() {
+    impl_->captured_inputs.clear();
+}
+
 void Compiler::store_input_element(const std::string& input_name,
                                    uint64_t addr_id, uint64_t modulus,
                                    const std::vector<uint64_t>& values) {

--- a/src/fhetch_sim/simulator.cpp
+++ b/src/fhetch_sim/simulator.cpp
@@ -44,9 +44,13 @@ struct Simulator::Impl {
 
     // Get polynomial from memory, returning zero-initialized if missing
     const std::vector<uint64_t>& get_or_zero(uint64_t addr,
-                                              std::vector<uint64_t>& scratch) {
+                                              std::vector<uint64_t>& scratch,
+                                              const Instruction& inst) {
         if (memory.is_initialized(addr))
             return memory.get(addr).values;
+        std::cerr << "[FHETCH_SIM] WARNING: read from uninitialized address %"
+                  << addr << " (line " << inst.line_number << ": "
+                  << inst.raw_line << ")" << std::endl;
         scratch.assign(ring_dim, 0);
         return scratch;
     }
@@ -62,8 +66,8 @@ struct Simulator::Impl {
     bool exec_addp(const Instruction& inst) {
         uint64_t q = resolve_modulus(inst.modulus_index);
         std::vector<uint64_t> scratch1, scratch2;
-        const auto& a = get_or_zero(inst.src1, scratch1);
-        const auto& b = get_or_zero(inst.src2, scratch2);
+        const auto& a = get_or_zero(inst.src1, scratch1, inst);
+        const auto& b = get_or_zero(inst.src2, scratch2, inst);
         if (a.size() != ring_dim || b.size() != ring_dim) {
             error(inst, "ring dimension mismatch"); return false;
         }
@@ -85,8 +89,8 @@ struct Simulator::Impl {
     bool exec_subp(const Instruction& inst) {
         uint64_t q = resolve_modulus(inst.modulus_index);
         std::vector<uint64_t> scratch1, scratch2;
-        const auto& a = get_or_zero(inst.src1, scratch1);
-        const auto& b = get_or_zero(inst.src2, scratch2);
+        const auto& a = get_or_zero(inst.src1, scratch1, inst);
+        const auto& b = get_or_zero(inst.src2, scratch2, inst);
         if (a.size() != ring_dim || b.size() != ring_dim) {
             error(inst, "ring dimension mismatch"); return false;
         }
@@ -108,8 +112,8 @@ struct Simulator::Impl {
     bool exec_mulp(const Instruction& inst) {
         uint64_t q = resolve_modulus(inst.modulus_index);
         std::vector<uint64_t> scratch1, scratch2;
-        const auto& a = get_or_zero(inst.src1, scratch1);
-        const auto& b = get_or_zero(inst.src2, scratch2);
+        const auto& a = get_or_zero(inst.src1, scratch1, inst);
+        const auto& b = get_or_zero(inst.src2, scratch2, inst);
         if (a.size() != ring_dim || b.size() != ring_dim) {
             error(inst, "ring dimension mismatch"); return false;
         }
@@ -131,8 +135,15 @@ struct Simulator::Impl {
     bool exec_addps(const Instruction& inst) {
         uint64_t q = resolve_modulus(inst.modulus_index);
         std::vector<uint64_t> scratch;
-        const auto& a = get_or_zero(inst.src1, scratch);
+        const auto& a = get_or_zero(inst.src1, scratch, inst);
         if (a.size() != ring_dim) { error(inst, "ring dimension mismatch"); return false; }
+
+        // Special case: immediate 0 = copy (no modular reduction).
+        // Used by copy probes where the modulus may not match the data.
+        if (inst.immediate == 0) {
+            memory.set(inst.dest, std::vector<uint64_t>(a), q);
+            return true;
+        }
 
         NativeInteger mod(q), imm(inst.immediate);
         NativeVector va(ring_dim, mod);
@@ -147,7 +158,7 @@ struct Simulator::Impl {
     bool exec_subps(const Instruction& inst) {
         uint64_t q = resolve_modulus(inst.modulus_index);
         std::vector<uint64_t> scratch;
-        const auto& a = get_or_zero(inst.src1, scratch);
+        const auto& a = get_or_zero(inst.src1, scratch, inst);
         if (a.size() != ring_dim) { error(inst, "ring dimension mismatch"); return false; }
 
         NativeInteger mod(q), imm(inst.immediate);
@@ -170,7 +181,7 @@ struct Simulator::Impl {
         }
 
         std::vector<uint64_t> scratch;
-        const auto& a = get_or_zero(inst.src1, scratch);
+        const auto& a = get_or_zero(inst.src1, scratch, inst);
         if (a.size() != ring_dim) { error(inst, "ring dimension mismatch"); return false; }
 
         NativeInteger mod(q), imm(inst.immediate);
@@ -186,7 +197,7 @@ struct Simulator::Impl {
     bool exec_negp(const Instruction& inst) {
         uint64_t q = resolve_modulus(inst.modulus_index);
         std::vector<uint64_t> scratch;
-        const auto& a = get_or_zero(inst.src1, scratch);
+        const auto& a = get_or_zero(inst.src1, scratch, inst);
         if (a.size() != ring_dim) { error(inst, "ring dimension mismatch"); return false; }
 
         std::vector<uint64_t> result(ring_dim);
@@ -199,7 +210,7 @@ struct Simulator::Impl {
     bool exec_ntt(const Instruction& inst) {
         uint64_t q = resolve_modulus(inst.modulus_index);
         std::vector<uint64_t> scratch;
-        const auto& a = get_or_zero(inst.src1, scratch);
+        const auto& a = get_or_zero(inst.src1, scratch, inst);
         if (a.size() != ring_dim) { error(inst, "ring dimension mismatch"); return false; }
 
         NativeInteger mod(q);
@@ -219,7 +230,7 @@ struct Simulator::Impl {
     bool exec_intt(const Instruction& inst) {
         uint64_t q = resolve_modulus(inst.modulus_index);
         std::vector<uint64_t> scratch;
-        const auto& a = get_or_zero(inst.src1, scratch);
+        const auto& a = get_or_zero(inst.src1, scratch, inst);
         if (a.size() != ring_dim) { error(inst, "ring dimension mismatch"); return false; }
 
         NativeInteger mod(q);

--- a/src/probes.cpp
+++ b/src/probes.cpp
@@ -143,9 +143,15 @@ void openfhe_cprobe_precompute(uintptr_t poly_id, int /*format*/) {
     map_address(poly_id);
 }
 
-void openfhe_cprobe_zero(uintptr_t poly_id, int /*format*/, uint64_t /*modulus*/) {
+void openfhe_cprobe_zero(uintptr_t poly_id, int /*format*/, uint64_t modulus) {
     std::lock_guard<std::mutex> lock(g_probe_mutex);
-    map_address(poly_id);
+    uintptr_t a = map_address(poly_id);
+
+    // Emit muli by 0 unconditionally to initialize the address to zero.
+    // emit_preamble works even before start().
+    std::string mi = (modulus != 0) ? midx(modulus) : "m=0";
+    niobium::detail::trace_writer().emit_preamble(
+        "sr_mulps " + addr(a) + ", " + addr(a) + ", 0, " + mi);
 }
 
 void openfhe_cprobe_max(uintptr_t poly_id, int /*format*/, uint64_t /*modulus*/) {
@@ -177,13 +183,18 @@ void openfhe_cprobe_key(uintptr_t poly_id, int /*format*/) {
 // ============================================================================
 
 void openfhe_cprobe_copy(uintptr_t dst_id, uintptr_t src_id) {
-    // Always track copies — even before start() — so the address lineage
-    // is preserved for simulator input population.
     std::lock_guard<std::mutex> lock(g_probe_mutex);
     if (g_serialization_thread) return;
     uintptr_t src_addr = map_address(src_id);
     uintptr_t dst_addr = map_address(dst_id);
     g_data_parent[dst_addr] = src_addr;
+
+    // Emit explicit copy unconditionally (even before start()).
+    // Pre-processing copies (format conversion, SetElementAtIndex) set up
+    // the address space the trace operates on. emit_preamble bypasses
+    // the recording check. The simulator treats addps with imm=0 as raw copy.
+    niobium::detail::trace_writer().emit_preamble(
+        "sr_addps " + addr(dst_addr) + ", " + addr(src_addr) + ", 0, m=0");
 }
 
 void openfhe_cprobe_move(uintptr_t dst_id, uintptr_t src_id) {
@@ -194,12 +205,10 @@ void openfhe_cprobe_move(uintptr_t dst_id, uintptr_t src_id) {
     // dst_id now points to the same FHETCH address as src_id
 }
 
-void openfhe_cprobe_reassign_id(uintptr_t dst_old, uintptr_t src) {
-    std::lock_guard<std::mutex> lock(g_probe_mutex);
-    auto it = g_address_map.find(src);
-    if (it != g_address_map.end()) {
-        g_address_map[dst_old] = it->second;
-    }
+void openfhe_cprobe_reassign_id(uintptr_t /*dst_old*/, uintptr_t /*src*/) {
+    // No-op: keep address mapping stable. PolyImpl::operator= fires
+    // copy+reassign+id_overwrite which would make the address map
+    // inconsistent between tag_input time and recording time.
 }
 
 void openfhe_cprobe_free(uintptr_t poly_id) {

--- a/src/trace_writer.cpp
+++ b/src/trace_writer.cpp
@@ -67,6 +67,11 @@ void TraceWriter::emit(const std::string& instruction) {
     }
 }
 
+void TraceWriter::emit_preamble(const std::string& instruction) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    instructions_.push_back(instruction);
+}
+
 void TraceWriter::comment(const std::string& text) {
     std::lock_guard<std::mutex> lock(mutex_);
     if (recording_ && !paused_) {

--- a/src/trace_writer.h
+++ b/src/trace_writer.h
@@ -37,6 +37,10 @@ public:
     // Emit a FHETCH instruction line into the trace.
     void emit(const std::string& instruction);
 
+    // Emit unconditionally (even before start_recording).
+    // Used for copy instructions that set up the simulator's address space.
+    void emit_preamble(const std::string& instruction);
+
     // Emit a comment line (prefixed with #).
     void comment(const std::string& text);
 


### PR DESCRIPTION
## Summary

- Mult example switched from BFV to CKKS (avoids BFV CRT basis extension gap)
- `openfhe_cprobe_copy` and `openfhe_cprobe_zero` now emit explicit trace instructions via `emit_preamble()` (unconditional, works before `start()`)
- `openfhe_cprobe_reassign_id` disabled to keep address mapping stable
- Simulator reports uninitialized address reads as warnings on stderr
- `TraceWriter::emit_preamble()` bypasses recording check for pre-start operations

## Status

- **EvalAdd**: works correctly (2*7+13=27 verified in previous PR)
- **EvalMult**: 40 uninitialized address warnings from key-switching digit decomposition. The digit polynomials' FHETCH addresses are orphaned because `PolyImpl::operator=` fires copy+reassign which shifts the address mapping. The copy writes to the pre-reassign address but subsequent probes use the post-reassign address.

## Test plan

- [ ] `make release` — build
- [ ] `make test-mult-release` — runs but EvalMult result not yet correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)