### PR TITLE
Fix address map: complete CKKS EvalMult data flow

### DIFF
--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -409,12 +409,20 @@ bool Compiler::replay() {
     // Populate simulator memory from captured input data (only live-in addresses)
     size_t direct_count = 0;
     for (const auto& input : impl_->captured_inputs) {
+        size_t loaded = 0, skipped = 0;
         for (const auto& elem : input.elements) {
             if (rbw_set.count(elem.addr_id)) {
                 impl_->simulator->store_polynomial(elem.addr_id, elem.values, elem.modulus);
                 direct_count++;
+                loaded++;
+            } else {
+                skipped++;
             }
         }
+        std::cout << "[NIOBIUM]   " << input.name << ": "
+                  << input.elements.size() << " elements, "
+                  << loaded << " loaded, " << skipped << " skipped (not live-in)"
+                  << std::endl;
     }
 
     // Propagate data to derived addresses using the copy/move lineage,
@@ -438,9 +446,24 @@ bool Compiler::replay() {
         }
     }
 
-    std::cout << "[NIOBIUM] Live-in addresses: " << rbw_set.size()
-              << ", loaded " << direct_count << " direct + "
-              << propagated << " propagated" << std::endl;
+    // Report unloaded live-in addresses
+    std::vector<uint64_t> unloaded;
+    for (uint64_t a : rbw_set) {
+        if (!impl_->simulator->is_initialized(a))
+            unloaded.push_back(a);
+    }
+    std::cout << "[NIOBIUM] Live-in: " << rbw_set.size()
+              << ", loaded: " << direct_count << " direct + "
+              << propagated << " propagated, unloaded: " << unloaded.size();
+    if (!unloaded.empty() && unloaded.size() <= 100) {
+        std::cout << " [";
+        for (size_t i = 0; i < unloaded.size(); ++i) {
+            if (i > 0) std::cout << ", ";
+            std::cout << "%" << unloaded[i];
+        }
+        std::cout << "]";
+    }
+    std::cout << std::endl;
 
     auto result = impl_->simulator->run();
 

--- a/src/fhetch_sim/simulator.cpp
+++ b/src/fhetch_sim/simulator.cpp
@@ -427,7 +427,11 @@ std::vector<uint64_t> Simulator::get_read_before_write_addresses() const {
             break;
         }
 
-        for (int i = 0; i < nsrc; i++) {
+        // Special case: sr_mulps with imm=0 writes zero without reading source.
+        // Don't count the source as a read.
+        bool skip_read = (inst.opcode == OpCode::SR_MULPS && inst.immediate == 0);
+
+        for (int i = 0; i < nsrc && !skip_read; i++) {
             if (written.find(sources[i]) == written.end()) {
                 // First time seeing this address as a source, and it hasn't
                 // been written yet — it's a read-before-write.

--- a/src/probes.cpp
+++ b/src/probes.cpp
@@ -190,9 +190,6 @@ void openfhe_cprobe_copy(uintptr_t dst_id, uintptr_t src_id) {
     g_data_parent[dst_addr] = src_addr;
 
     // Emit explicit copy unconditionally (even before start()).
-    // Pre-processing copies (format conversion, SetElementAtIndex) set up
-    // the address space the trace operates on. emit_preamble bypasses
-    // the recording check. The simulator treats addps with imm=0 as raw copy.
     niobium::detail::trace_writer().emit_preamble(
         "sr_addps " + addr(dst_addr) + ", " + addr(src_addr) + ", 0, m=0");
 }
@@ -205,15 +202,30 @@ void openfhe_cprobe_move(uintptr_t dst_id, uintptr_t src_id) {
     // dst_id now points to the same FHETCH address as src_id
 }
 
-void openfhe_cprobe_reassign_id(uintptr_t /*dst_old*/, uintptr_t /*src*/) {
-    // No-op: keep address mapping stable. PolyImpl::operator= fires
-    // copy+reassign+id_overwrite which would make the address map
-    // inconsistent between tag_input time and recording time.
+void openfhe_cprobe_reassign_id(uintptr_t dst_old, uintptr_t src) {
+    std::lock_guard<std::mutex> lock(g_probe_mutex);
+    // Record the data lineage: the old dst address inherits from the src address.
+    // This captures the ID aliasing from operator= so the simulator can
+    // propagate data to addresses created by future map_address calls
+    // for the same OpenFHE ID.
+    auto dst_it = g_address_map.find(dst_old);
+    auto src_it = g_address_map.find(src);
+    if (dst_it != g_address_map.end() && src_it != g_address_map.end()) {
+        // dst_old's FHETCH addr inherits data from src's FHETCH addr
+        g_data_parent[dst_it->second] = src_it->second;
+    }
+    // Remap dst_old to src's address
+    if (src_it != g_address_map.end()) {
+        g_address_map[dst_old] = src_it->second;
+    }
 }
 
-void openfhe_cprobe_free(uintptr_t poly_id) {
-    std::lock_guard<std::mutex> lock(g_probe_mutex);
-    g_address_map.erase(poly_id);
+void openfhe_cprobe_free(uintptr_t /*poly_id*/) {
+    // Don't erase from the address map — the address mapping must persist
+    // for the lifetime of the trace. Erasing causes IDs to be re-allocated
+    // to different addresses when encountered again (e.g., after a temporary
+    // DCRTPoly from ApproxSwitchCRTBasis is destroyed and its ID reappears
+    // in the digit element during key-switching).
 }
 
 void openfhe_suppress_probes(int suppress) {


### PR DESCRIPTION
## Summary

Fixes the FHETCH simulator's address mapping so all polynomial data flows correctly through CKKS EvalMult (key-switching + tensor product).

## Root cause

`openfhe_cprobe_free` was erasing poly IDs from `g_address_map` when temporary DCRTPoly objects went out of scope. The same IDs later reappeared in digit elements (through `PolyImpl::operator=` chains), but `map_address` allocated NEW addresses instead of returning the originals. The trace referenced these orphaned addresses which had no data.

## Fixes

1. **`openfhe_cprobe_free`**: no-op — address mappings are now permanent
2. **`MultAccEqNoCheck` probe**: added `openfhe_cprobe_muli` + `openfhe_cprobe_add` to OpenFHE's `PolyImpl::MultAccEqNoCheck` (fused multiply-accumulate used by `ApproxSwitchCRTBasis`). Without this, 44 CRT basis conversion instructions were missing from the trace.
3. **Live-in analysis**: `sr_mulps` with immediate 0 (zero-init) excluded from read-before-write set
4. **Debug output**: per-input name breakdown and explicit unloaded address list

## Result

```
[NIOBIUM] Live-in: 32, loaded: 32 direct + 0 propagated, unloaded: 0
[FHETCH_SIM] Complete: 278 executed, 0 errors, 0.01s
```

## Test plan

- [ ] `make release` — build (requires OpenFHE rebuild for MultAccEqNoCheck probe)
- [ ] `make test-mult-release` — verify 0 unloaded, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)