### PR TITLE
Pass NTT/INTT omega through trace to simulator

### DIFF
--- a/src/fhetch_sim/instruction.cpp
+++ b/src/fhetch_sim/instruction.cpp
@@ -221,15 +221,28 @@ ParsedTrace parse_trace(const std::string& trace_text) {
             }
             break;
 
-        // unary with modulus: dest, src1, m=N
+        // unary with modulus: dest, src1, m=N [, omega=V]
         case OpCode::SR_NEGP:
-        case OpCode::SR_NTT:
-        case OpCode::SR_INTT:
         case OpCode::SR_PERMUTE:
             if (args.size() >= 3) {
                 parse_addr(args[0], inst.dest);
                 parse_addr(args[1], inst.src1);
                 parse_modulus_ref(args[2], inst.modulus_index);
+            }
+            break;
+
+        // NTT/INTT: dest, src1, m=N, omega=V
+        case OpCode::SR_NTT:
+        case OpCode::SR_INTT:
+            if (args.size() >= 3) {
+                parse_addr(args[0], inst.dest);
+                parse_addr(args[1], inst.src1);
+                parse_modulus_ref(args[2], inst.modulus_index);
+                if (args.size() >= 4) {
+                    uint64_t w;
+                    if (parse_named_uint(args[3], "omega=", w))
+                        inst.omega = w;
+                }
             }
             break;
 

--- a/src/fhetch_sim/instruction.h
+++ b/src/fhetch_sim/instruction.h
@@ -41,6 +41,7 @@ struct Instruction {
     uint32_t modulus_index = 0;     // Index into the modulus table (m=N)
     std::optional<uint64_t> k;      // Automorphism index
     std::optional<uint64_t> offset; // Rotation offset
+    std::optional<uint64_t> omega;  // NTT root of unity
     std::string comment;            // Comment text (for COMMENT opcode)
     std::string raw_line;           // Original text
     int line_number = 0;

--- a/src/fhetch_sim/simulator.cpp
+++ b/src/fhetch_sim/simulator.cpp
@@ -217,7 +217,13 @@ struct Simulator::Impl {
         NativeVector va(ring_dim, mod);
         for (size_t i = 0; i < ring_dim; i++) va[i] = NativeInteger(a[i]);
 
-        NativeInteger root = RootOfUnity<NativeInteger>(2 * ring_dim, mod);
+        // Use omega from trace if available, otherwise compute
+        NativeInteger root;
+        if (inst.omega.has_value() && inst.omega.value() != 0) {
+            root = NativeInteger(inst.omega.value());
+        } else {
+            root = RootOfUnity<NativeInteger>(2 * ring_dim, mod);
+        }
         ChineseRemainderTransformFTT<NativeVector> transformer;
         transformer.ForwardTransformToBitReverse(va, root, 2 * ring_dim, &va);
 
@@ -237,7 +243,12 @@ struct Simulator::Impl {
         NativeVector va(ring_dim, mod);
         for (size_t i = 0; i < ring_dim; i++) va[i] = NativeInteger(a[i]);
 
-        NativeInteger root = RootOfUnity<NativeInteger>(2 * ring_dim, mod);
+        NativeInteger root;
+        if (inst.omega.has_value() && inst.omega.value() != 0) {
+            root = NativeInteger(inst.omega.value());
+        } else {
+            root = RootOfUnity<NativeInteger>(2 * ring_dim, mod);
+        }
         ChineseRemainderTransformFTT<NativeVector> transformer;
         transformer.InverseTransformFromBitReverse(va, root, 2 * ring_dim, &va);
 

--- a/src/probes.cpp
+++ b/src/probes.cpp
@@ -312,19 +312,23 @@ void openfhe_cprobe_muli(uintptr_t dst, uintptr_t src, uint64_t immediate,
 // ============================================================================
 
 void openfhe_cprobe_ntt(uintptr_t dst, uintptr_t src, uint64_t modulus,
-                        uint64_t /*omega*/) {
+                        uint64_t omega) {
     if (!should_record()) return;
     std::lock_guard<std::mutex> lock(g_probe_mutex);
-    emit("sr_ntt " + addr(map_address(dst)) + ", " +
-         addr(map_address(src)) + ", " + midx(modulus));
+    uintptr_t da = map_address(dst);
+    uintptr_t sa = resolve_inplace_src(map_address(src), da);
+    emit("sr_ntt " + addr(da) + ", " + addr(sa) + ", " + midx(modulus) +
+         ", omega=" + std::to_string(omega));
 }
 
 void openfhe_cprobe_intt(uintptr_t dst, uintptr_t src, uint64_t modulus,
-                         uint64_t /*omega*/) {
+                         uint64_t omega) {
     if (!should_record()) return;
     std::lock_guard<std::mutex> lock(g_probe_mutex);
-    emit("sr_intt " + addr(map_address(dst)) + ", " +
-         addr(map_address(src)) + ", " + midx(modulus));
+    uintptr_t da = map_address(dst);
+    uintptr_t sa = resolve_inplace_src(map_address(src), da);
+    emit("sr_intt " + addr(da) + ", " + addr(sa) + ", " + midx(modulus) +
+         ", omega=" + std::to_string(omega));
 }
 
 void openfhe_cprobe_automorphism(uintptr_t dst, uintptr_t src,


### PR DESCRIPTION
## Summary

The simulator was computing its own primitive root of unity via `RootOfUnity(2*N, q)` which could differ from the root OpenFHE used during recording. This caused NTT/INTT results to be mathematically valid but incompatible with the recorded data.

## Changes

- **Probes**: `openfhe_cprobe_ntt`/`intt` now emit `omega=V` parameter in the trace. Also apply `resolve_inplace_src` to NTT/INTT source operands.
- **Parser**: extracts `omega=` into `Instruction::omega` field
- **Simulator**: uses `inst.omega` when available, falls back to computed root only when absent

## Trace format

```
sr_ntt %75, %75, m=2, omega=1907696064
sr_intt %73, %68, m=0, omega=21386457317996
```

## Test plan

- [ ] `make release` — build
- [ ] `make test-mult-release` — verify omega values in trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)