### PR TITLE
Fix CKKS rotation (MORPH) simulation, add MUL_MUL test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,7 @@ test-bootstrap-release: build-release ## Run the bootstrap example: client → s
 
 test-mult: build ## Run the multiply example: client → server → decrypt (Debug)
 	$(call set-build-config,Debug,dbuild)
+	@rm -rf mult_keys mult_server_workload_*
 	@echo "=== Running mult client ==="
 	$(BUILD_DIR)/examples/mult_client mult_keys 7 13
 	@echo ""
@@ -209,6 +210,7 @@ test-mult: build ## Run the multiply example: client → server → decrypt (Deb
 
 test-mult-release: build-release ## Run the multiply example: client → server → decrypt (Release)
 	$(call set-build-config,Release,build)
+	@rm -rf mult_keys mult_server_workload_*
 	@echo "=== Running mult client ==="
 	$(BUILD_DIR)/examples/mult_client mult_keys 7 13
 	@echo ""
@@ -254,9 +256,10 @@ test-simple-ops: build ## Run all simple_ops tests (Debug)
 	$(call run-simple-op,ADD_ADD,5,6)
 	$(call run-simple-op,ADD_SUB,5,6)
 	$(call run-simple-op,MUL,5,6)
-	$(call run-simple-op,MORPH,5,6)
 	$(call run-simple-op,MUL_ADD,5,6)
 	$(call run-simple-op,ADD_MUL,5,6)
+	$(call run-simple-op,MUL_MUL,5,6)
+	$(call run-simple-op,MORPH,5,6)
 
 test-simple-ops-release: build-release ## Run all simple_ops tests (Release)
 	$(call set-build-config,Release,build)
@@ -269,9 +272,10 @@ test-simple-ops-release: build-release ## Run all simple_ops tests (Release)
 	$(call run-simple-op,ADD_ADD,5,6)
 	$(call run-simple-op,ADD_SUB,5,6)
 	$(call run-simple-op,MUL,5,6)
-	$(call run-simple-op,MORPH,5,6)
 	$(call run-simple-op,MUL_ADD,5,6)
 	$(call run-simple-op,ADD_MUL,5,6)
+	$(call run-simple-op,MUL_MUL,5,6)
+	$(call run-simple-op,MORPH,5,6)
 
 test-op-release: build-release ## Run a single simple_ops test: make test-op-release OP=ADD A=5 B=6
 	$(call set-build-config,Release,build)

--- a/examples/simple_ops/decrypt.cpp
+++ b/examples/simple_ops/decrypt.cpp
@@ -62,6 +62,7 @@ int main(int argc, char* argv[]) {
     else if (operation == "ADD_SUB") expected = b;
     else if (operation == "MUL_ADD") expected = a * b + a;
     else if (operation == "ADD_MUL") expected = (a + b) * a;
+    else if (operation == "MUL_MUL") expected = a * b * a;
     else if (operation == "ALL_NO_MUL") expected = (b + 1.0) * 4.0;
     else if (operation == "MORPH")   expected = b;  // EvalRotate(ct_a={a,b}, 1)[0]
     else {

--- a/examples/simple_ops/server.cpp
+++ b/examples/simple_ops/server.cpp
@@ -87,6 +87,10 @@ int main(int argc, char* argv[]) {
     if (has_mult_key)
         niobium::compiler().tag_keys(cc);
 
+    // Saved copy of OpenFHE's own computed result — diffed against the
+    // simulator's output after replay.
+    Ciphertext<DCRTPoly> ct_openfhe;
+
     if (!niobium::compiler().is_cache_valid()) {
         std::cout << "\n--- Recording " << operation << " ---" << std::endl;
         niobium::compiler().start();
@@ -119,6 +123,9 @@ int main(int argc, char* argv[]) {
         } else if (operation == "ADD_MUL") {
             auto tmp = cc->EvalAdd(ct_a, ct_b);
             result = cc->EvalMult(tmp, ct_a);
+        } else if (operation == "MUL_MUL") {
+            auto tmp = cc->EvalMult(ct_a, ct_b);
+            result = cc->EvalMult(tmp, ct_a);
         } else if (operation == "ALL_NO_MUL") {
             // Combines: add, sub, neg, addi, subi, muli
             // ((a + b) - a + 3 - 2) * 4 = (b + 1) * 4
@@ -135,12 +142,13 @@ int main(int argc, char* argv[]) {
             result = cc->EvalRotate(ct_a, 1);
         } else {
             std::cerr << "Unknown operation: " << operation << std::endl;
-            std::cerr << "Valid: ADD SUB MUL NEG ADDI SUBI MULI ADD_ADD ADD_SUB MUL_ADD ADD_MUL ALL_NO_MUL MORPH" << std::endl;
+            std::cerr << "Valid: ADD SUB MUL NEG ADDI SUBI MULI ADD_ADD ADD_SUB MUL_ADD ADD_MUL MUL_MUL ALL_NO_MUL MORPH" << std::endl;
             return 1;
         }
 
         niobium::compiler().probe("result", result);
         niobium::compiler().stop();
+        ct_openfhe = result;
     }
 
     // ---- Replay ----
@@ -153,6 +161,44 @@ int main(int argc, char* argv[]) {
     // ---- Retrieve and serialize result ----
     Ciphertext<DCRTPoly> ct_result;
     if (niobium::compiler().result(cc, "result", ct_result)) {
+        if (ct_openfhe) {
+            std::cout << "\n--- Differential: simulator vs OpenFHE ---" << std::endl;
+            const auto& oe = ct_openfhe->GetElements();
+            const auto& sm = ct_result->GetElements();
+            if (oe.size() != sm.size()) {
+                std::cerr << "[DIFF] ciphertext size mismatch: "
+                          << oe.size() << " vs " << sm.size() << std::endl;
+            } else {
+                for (size_t c = 0; c < oe.size(); ++c) {
+                    const auto& oet = oe[c].GetAllElements();
+                    const auto& smt = sm[c].GetAllElements();
+                    for (size_t t = 0; t < oet.size(); ++t) {
+                        const auto& ov = oet[t].GetValues();
+                        const auto& sv = smt[t].GetValues();
+                        size_t diffs = 0; size_t first = 0;
+                        uint64_t oe0 = 0, sm0 = 0;
+                        for (size_t i = 0; i < ov.GetLength(); ++i) {
+                            if (ov[i] != sv[i]) {
+                                if (diffs == 0) { first = i;
+                                    oe0 = ov[i].ConvertToInt();
+                                    sm0 = sv[i].ConvertToInt(); }
+                                ++diffs;
+                            }
+                        }
+                        std::cout << "  comp=" << c << " tower=" << t
+                                  << " mod=0x" << std::hex << oet[t].GetModulus().ConvertToInt() << std::dec
+                                  << (diffs == 0 ? "  MATCH"
+                                      : "  DIVERGE at [" + std::to_string(first)
+                                        + "]: openfhe=" + std::to_string(oe0)
+                                        + " sim=" + std::to_string(sm0)
+                                        + " (" + std::to_string(diffs) + "/"
+                                        + std::to_string(ov.GetLength()) + ")")
+                                  << std::endl;
+                    }
+                }
+            }
+            std::cout << std::endl;
+        }
         Serial::SerializeToFile(keyDir + "/ct_result.bin", ct_result, SerType::BINARY);
         std::cout << "Result written to " << keyDir << "/ct_result.bin" << std::endl;
     } else {

--- a/src/fhetch_sim/instruction.cpp
+++ b/src/fhetch_sim/instruction.cpp
@@ -256,15 +256,17 @@ ParsedTrace parse_trace(const std::string& trace_text) {
             }
             break;
 
-        // automorphism: dest, src1, k=N, m=N
+        // automorphism: dest, src1, m=N, mask=N, logn=N, k=N
+        // (named args can be in any order after src1; we pick up k= and m= by name)
         case OpCode::SR_AUTOMORPH_EVAL:
             if (args.size() >= 3) {
                 parse_addr(args[0], inst.dest);
                 parse_addr(args[1], inst.src1);
-                uint64_t kval;
-                if (parse_named_uint(args[2], "k=", kval)) inst.k = kval;
-                if (args.size() >= 4)
-                    parse_modulus_ref(args[3], inst.modulus_index);
+                for (size_t i = 2; i < args.size(); ++i) {
+                    uint64_t v;
+                    if (parse_named_uint(args[i], "k=", v)) inst.k = v;
+                    else parse_modulus_ref(args[i], inst.modulus_index);
+                }
             }
             break;
 

--- a/src/fhetch_sim/simulator.cpp
+++ b/src/fhetch_sim/simulator.cpp
@@ -233,6 +233,44 @@ struct Simulator::Impl {
         return true;
     }
 
+    // AutomorphismTransform for power-of-2 ring in EVALUATION form.
+    // Mirrors OpenFHE's PolyImpl::AutomorphismTransform(k) (poly-impl.h:494):
+    //   logn = log2(N)
+    //   mask = N - 1
+    //   for (j=0, jk=k; j < N; ++j, jk += 2k):
+    //       result[ReverseBits(j, logn)] = values[ReverseBits((jk>>1)&mask, logn)]
+    bool exec_automorph_eval(const Instruction& inst) {
+        uint64_t q = resolve_modulus(inst.modulus_index);
+        std::vector<uint64_t> scratch;
+        const auto& a = get_or_zero(inst.src1, scratch, inst);
+        if (a.size() != ring_dim) { error(inst, "ring dimension mismatch"); return false; }
+        if (!inst.k.has_value()) {
+            error(inst, "automorphism missing k"); return false;
+        }
+        uint32_t k = static_cast<uint32_t>(inst.k.value());
+        // logn such that (1 << logn) == ring_dim
+        uint32_t logn = 0;
+        for (uint32_t n = static_cast<uint32_t>(ring_dim); n > 1; n >>= 1) ++logn;
+        uint32_t mask = (1u << logn) - 1u;
+
+        auto rev_bits = [](uint32_t x, uint32_t bits) {
+            uint32_t r = 0;
+            for (uint32_t i = 0; i < bits; ++i)
+                if (x & (1u << i)) r |= 1u << (bits - 1 - i);
+            return r;
+        };
+
+        std::vector<uint64_t> result(ring_dim, 0);
+        uint32_t jk = k;
+        for (uint32_t j = 0; j < ring_dim; ++j, jk += 2 * k) {
+            uint32_t jrev = rev_bits(j, logn);
+            uint32_t idxrev = rev_bits((jk >> 1) & mask, logn);
+            result[jrev] = a[idxrev];
+        }
+        memory.set(inst.dest, std::move(result), q);
+        return true;
+    }
+
     bool exec_intt(const Instruction& inst) {
         uint64_t q = resolve_modulus(inst.modulus_index);
         std::vector<uint64_t> scratch;
@@ -293,11 +331,12 @@ struct Simulator::Impl {
             case OpCode::SR_NTT:         ok = exec_ntt(inst);   break;
             case OpCode::SR_INTT:        ok = exec_intt(inst);  break;
 
+            case OpCode::SR_AUTOMORPH_EVAL: ok = exec_automorph_eval(inst); break;
+
             case OpCode::SR_PERMUTE:
-            case OpCode::SR_AUTOMORPH_EVAL:
             case OpCode::SR_AUTOMORPH_COEFF:
             case OpCode::SR_ROT_AUTOMORPH_COEFF:
-                // TODO: permutation/automorphism simulation
+                // TODO: COEFF-form automorphism not yet used by our tests
                 ok = true;
                 break;
 

--- a/src/probes.cpp
+++ b/src/probes.cpp
@@ -349,15 +349,23 @@ void openfhe_cprobe_intt(uintptr_t dst, uintptr_t src, uint64_t modulus,
          ", omega=" + std::to_string(omega));
 }
 
+// OpenFHE's poly-impl.h calls this as:
+//   openfhe_cprobe_automorphism(result.GetId(), GetId(), q.ConvertToInt(),
+//                               mask, logn, k);
+// so the third argument is the *modulus*, followed by mask, logn, k.
 void openfhe_cprobe_automorphism(uintptr_t dst, uintptr_t src,
-                                 uint64_t k, uint64_t modulus,
-                                 uint64_t /*ring_dim*/,
-                                 uint64_t /*root_of_unity*/) {
+                                 uint64_t modulus, uint64_t mask,
+                                 uint64_t logn, uint64_t k) {
     if (!should_record()) return;
     std::lock_guard<std::mutex> lock(g_probe_mutex);
-    emit("sr_automorph_eval " + addr(map_address(dst)) + ", " +
-         addr(map_address(src)) + ", k=" + std::to_string(k) +
-         ", " + midx(modulus));
+    uintptr_t da = map_address(dst);
+    uintptr_t sa = resolve_inplace_src(map_address(src), da);
+    emit("sr_automorph_eval " + addr(da) + ", " + addr(sa) +
+         ", " + midx(modulus) +
+         ", mask=" + std::to_string(mask) +
+         ", logn=" + std::to_string(logn) +
+         ", k=" + std::to_string(k));
+    invalidate_clone_parent_on_write(da);
 }
 
 void openfhe_cprobe_switchmodulus(uintptr_t dst, uintptr_t src,


### PR DESCRIPTION
## Summary

Gets the \`MORPH\` (CKKS \`EvalRotate\`) simulator test passing — last failing op in the simple_ops suite. Adds a \`MUL_MUL\` compound test along the way. All 13 simple_ops now green.

## MORPH root cause — three interlocking bugs

1. **Probe argument order mismatch** (\`src/probes.cpp\`). OpenFHE calls:
   \`\`\`cpp
   openfhe_cprobe_automorphism(result_id, src_id, q, mask, logn, k);
   \`\`\`
   but the client named its params \`(dst, src, k, modulus, ring_dim, root_of_unity)\` — so what we wrote to the trace as \`k=…\` was actually the modulus value, and the modulus index we registered was derived from \`mask\`. Fixed by correcting the parameter mapping and emitting explicit \`m=, mask=, logn=, k=\` fields.

2. **Parser positional** (\`src/fhetch_sim/instruction.cpp\`). Old parser expected \`k=, m=\` in fixed positions; rewrote it to pick up named fields by key so \`mask=, logn=\` don't break parsing.

3. **Simulator no-op** (\`src/fhetch_sim/simulator.cpp\`). \`SR_AUTOMORPH_EVAL\` was a TODO, so the destination stayed all-zero after the instruction and every downstream op on that register cascaded to zero. Implemented following OpenFHE's \`PolyImpl::AutomorphismTransform(k)\` for power-of-two rings in EVALUATION form (bit-reversed index gather):
   \`\`\`cpp
   for (j=0, jk=k; j<N; ++j, jk += 2k):
       result[ReverseBits(j, logn)] = src[ReverseBits((jk>>1) & mask, logn)]
   \`\`\`

## Debug infrastructure

- Ported the \`simulator vs OpenFHE\` ciphertext differential that localized the MUL bug to \`simple_ops/server.cpp\`. It immediately showed \`sim=0\` for every tower and every slot, pointing directly at an unimplemented instruction.
- \`test-mult-release\` / \`test-mult\` now clear stale workload directories before running — prevents the cache-hit replays of pre-fix traces that caused the false \"test-mult-release is failing\" report earlier.

## New MUL_MUL test

\`(a * b) * a\` — matches the compiler's \`op_mul_mul\`. Exercises two chained relinearization steps at depth=3 and passes.

## Test results

| Op | Before | After |
|---|---|---|
| ADD, SUB, NEG, ADDI, SUBI, MULI, ADD_ADD, ADD_SUB | ✓ | ✓ |
| MUL, MUL_ADD, ADD_MUL | ✓ (from PR #15) | ✓ |
| **MUL_MUL** | — | ✓ (new) |
| **MORPH** | ❌ (all-zero sim output) | ✓ |

\`\`\`
[PASS] ADD: 11 ~= 11
[PASS] SUB: -1 ~= -1
[PASS] NEG: -5 ~= -5
[PASS] ADDI: 8 ~= 8
[PASS] SUBI: 3 ~= 3
[PASS] MULI: 20 ~= 20
[PASS] ADD_ADD: 16 ~= 16
[PASS] ADD_SUB: 6 ~= 6
[PASS] MUL: 30 ~= 30
[PASS] MUL_ADD: 35 ~= 35
[PASS] ADD_MUL: 55 ~= 55
[PASS] MUL_MUL: 150 ~= 150
[PASS] MORPH: 6 ~= 6
\`\`\`

## Test plan
- [ ] \`make test-simple-ops-release\` — 13/13 PASS
- [ ] \`make test-op-release OP=MORPH A=5 B=6\` — rotates \`{5,6}\` left by 1, slot 0 = 6
- [ ] \`make test-op-release OP=MUL_MUL A=5 B=6\` — 5*6*5 = 150
- [ ] \`make test-mult-release\` — no stale cache interference

🤖 Generated with [Claude Code](https://claude.com/claude-code)