### PR TITLE
Bootstrap: tag_bootstrap_precompute + .bp.bin/.bp.ids serialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,21 +180,29 @@ install-release: ## Install the client library (Release mode)
 
 ##@ Testing
 
-test-bootstrap: build ## Run the bootstrap example: client → server with hollow recording (Debug)
+test-bootstrap: build ## Run the bootstrap example: client → server → decrypt (Debug)
 	$(call set-build-config,Debug,dbuild)
+	@rm -rf bootstrap_keys bootstrap_server_*
 	@echo "=== Running bootstrap client ==="
 	$(BUILD_DIR)/examples/bootstrap_client bootstrap_keys
 	@echo ""
-	@echo "=== Running bootstrap server (hollow mode) ==="
+	@echo "=== Running bootstrap server ==="
 	$(BUILD_DIR)/examples/bootstrap_server bootstrap_keys
+	@echo ""
+	@echo "=== Running bootstrap decrypt ==="
+	$(BUILD_DIR)/examples/bootstrap_decrypt bootstrap_keys
 
-test-bootstrap-release: build-release ## Run the bootstrap example: client → server with hollow recording (Release)
+test-bootstrap-release: build-release ## Run the bootstrap example: client → server → decrypt (Release)
 	$(call set-build-config,Release,build)
+	@rm -rf bootstrap_keys bootstrap_server_*
 	@echo "=== Running bootstrap client ==="
 	$(BUILD_DIR)/examples/bootstrap_client bootstrap_keys
 	@echo ""
-	@echo "=== Running bootstrap server (hollow mode) ==="
+	@echo "=== Running bootstrap server ==="
 	$(BUILD_DIR)/examples/bootstrap_server bootstrap_keys
+	@echo ""
+	@echo "=== Running bootstrap decrypt ==="
+	$(BUILD_DIR)/examples/bootstrap_decrypt bootstrap_keys
 
 test-mult: build ## Run the multiply example: client → server → decrypt (Debug)
 	$(call set-build-config,Debug,dbuild)

--- a/examples/bootstrap/server.cpp
+++ b/examples/bootstrap/server.cpp
@@ -78,6 +78,10 @@ int main(int argc, char* argv[]) {
     // ---- Capture crypto context and keys for simulator ----
     niobium::compiler().capture_crypto_context(cc);
     niobium::compiler().tag_keys(cc);
+    // Bootstrap precompute plaintexts are created by EvalBootstrapSetup
+    // before start() — tag them here so `.bp.bin`/`.bp.ids` are on disk
+    // before fhetch_replay.json gets written in stop().
+    niobium::compiler().tag_bootstrap_precompute(cc);
 
     // ---- Tag the input ciphertext ----
     niobium::compiler().tag_input("input_cipher", ciph);
@@ -103,11 +107,6 @@ int main(int argc, char* argv[]) {
         niobium::compiler().stop();
         niobium::compiler().enable_hollow_mode(false);
     }
-
-    // Tag bootstrap precompute plaintexts AFTER recording stops, when all
-    // poly addresses are final (matches the compiler's record_bootstrap_precomp
-    // timing, which runs during the save-trace phase).
-    niobium::compiler().tag_bootstrap_precompute(cc);
 
     // ---- REPLAY: execute trace through the FHETCH simulator ----
     std::cout << "\n--- Replay ---" << std::endl;

--- a/examples/bootstrap/server.cpp
+++ b/examples/bootstrap/server.cpp
@@ -82,10 +82,19 @@ int main(int argc, char* argv[]) {
     // ---- Tag the input ciphertext ----
     niobium::compiler().tag_input("input_cipher", ciph);
 
+    // Hollow mode skips OpenFHE's real math during recording, which is fast
+    // but leaves intermediate polys uninitialized for the simulator.
+    // NIOBIUM_BOOTSTRAP_HOLLOW=0 forces real-math recording so every derived
+    // poly is populated before the simulator runs.
+    bool hollow = true;
+    {
+        const char* e = std::getenv("NIOBIUM_BOOTSTRAP_HOLLOW");
+        if (e && std::string(e) == "0") hollow = false;
+    }
+
     if (!niobium::compiler().is_cache_valid()) {
-        // ---- RECORDING PHASE (hollow mode) ----
-        std::cout << "\n--- Recording bootstrap operation (hollow mode) ---" << std::endl;
-        niobium::compiler().enable_hollow_mode(true);
+        std::cout << "\n--- Recording bootstrap (" << (hollow ? "hollow" : "real") << " mode) ---" << std::endl;
+        niobium::compiler().enable_hollow_mode(hollow);
         niobium::compiler().start();
 
         auto ciphertextAfter = cc->EvalBootstrap(ciph);
@@ -95,6 +104,11 @@ int main(int argc, char* argv[]) {
         niobium::compiler().enable_hollow_mode(false);
     }
 
+    // Tag bootstrap precompute plaintexts AFTER recording stops, when all
+    // poly addresses are final (matches the compiler's record_bootstrap_precomp
+    // timing, which runs during the save-trace phase).
+    niobium::compiler().tag_bootstrap_precompute(cc);
+
     // ---- REPLAY: execute trace through the FHETCH simulator ----
     std::cout << "\n--- Replay ---" << std::endl;
     if (!niobium::compiler().replay()) {
@@ -102,5 +116,16 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // ---- Extract the simulator's reconstructed probe and serialize ----
+    Ciphertext<DCRTPoly> ct_result;
+    if (!niobium::compiler().result(cc, "output_cipher", ct_result)) {
+        std::cerr << "[ERROR] Could not retrieve output_cipher probe" << std::endl;
+        return 1;
+    }
+    if (!Serial::SerializeToFile(keyDir + "/ct_result.bin", ct_result, SerType::BINARY)) {
+        std::cerr << "[ERROR] Failed to serialize result ciphertext" << std::endl;
+        return 1;
+    }
+    std::cout << "Result ciphertext written to " << keyDir << "/ct_result.bin" << std::endl;
     return 0;
 }

--- a/include/niobium/compiler.h
+++ b/include/niobium/compiler.h
@@ -174,6 +174,14 @@ public:
     template<typename CryptoContextType>
     void tag_keys(const CryptoContextType& cc);
 
+    /// Capture CKKS bootstrap precomputation plaintext polynomials so the
+    /// simulator can read from them during replay. Walks the FHECKKSRNS
+    /// `m_bootPrecomMap` and tags every DCRTPoly inside m_U0Pre /
+    /// m_U0hatTPre / m_U0PreFFT / m_U0hatTPreFFT as live-in data.
+    /// Call after EvalBootstrapSetup() and before start().
+    template<typename CryptoContextType>
+    void tag_bootstrap_precompute(const CryptoContextType& cc);
+
     // ====================================================================
     // RECORDING MODES
     // ====================================================================

--- a/src/auto_facade.cpp
+++ b/src/auto_facade.cpp
@@ -427,6 +427,9 @@ void Compiler::tag_keys<lbcrypto::CryptoContext<DCRTPoly>>(
 // m_bootPrecomMap via its probe-exposed accessor (GetBootPrecomMap), and
 // captures every DCRTPoly inside m_U0Pre / m_U0hatTPre / m_U0PreFFT /
 // m_U0hatTPreFFT as an input under the "bootstrap_precompute" name.
+//
+// Also serializes the captured data to disk as `.bp.bin` + `.bp.ids`,
+// matching niobium-compiler's CerealIO::write_bootstrap_precomp format.
 template<>
 void Compiler::tag_bootstrap_precompute<lbcrypto::CryptoContext<DCRTPoly>>(
     const lbcrypto::CryptoContext<DCRTPoly>& cc) {
@@ -441,28 +444,79 @@ void Compiler::tag_bootstrap_precompute<lbcrypto::CryptoContext<DCRTPoly>>(
     const auto& bootMap = fheCkks->GetBootPrecomMap();
     if (bootMap.empty()) return;
 
+    // Same traversal order as the compiler's write_bootstrap_precomp:
+    // per-slot entry, then m_U0hatTPreFFT, m_U0PreFFT, m_U0Pre, m_U0hatTPre.
     std::vector<uint64_t> addr_ids;
     auto capture_pt = [&](const auto& pt) {
         if (!pt) return;
-        // Plaintext wraps a single DCRTPoly; reuse capture_dcrt_polys.
         const auto& el = pt->template GetElement<lbcrypto::DCRTPoly>();
         std::vector<DCRTPoly> one;
         one.push_back(el);
         capture_dcrt_polys(*this, "bootstrap_precompute", one, addr_ids);
     };
 
-    size_t before = addr_ids.size();
     for (const auto& [slots, precom] : bootMap) {
         if (!precom) continue;
-        for (const auto& pt : precom->m_U0Pre) capture_pt(pt);
-        for (const auto& pt : precom->m_U0hatTPre) capture_pt(pt);
-        for (const auto& inner : precom->m_U0PreFFT)
-            for (const auto& pt : inner) capture_pt(pt);
         for (const auto& inner : precom->m_U0hatTPreFFT)
             for (const auto& pt : inner) capture_pt(pt);
+        for (const auto& inner : precom->m_U0PreFFT)
+            for (const auto& pt : inner) capture_pt(pt);
+        for (const auto& pt : precom->m_U0Pre) capture_pt(pt);
+        for (const auto& pt : precom->m_U0hatTPre) capture_pt(pt);
     }
-    std::cout << "[NIOBIUM] Tagged " << (addr_ids.size() - before)
+
+    std::cout << "[NIOBIUM] Tagged " << addr_ids.size()
               << " bootstrap precompute polynomials" << std::endl;
+
+    // Write .bp.bin and .bp.ids to disk (compiler-parity format).
+    auto dir = get_program_directory();
+    std::filesystem::create_directories(dir);
+    std::string prog = program_name();
+
+    auto ids_path = dir / (prog + ".bp.ids");
+    cereal_io::write_addr_ids(ids_path, addr_ids);
+
+    auto bin_path = dir / (prog + ".bp.bin");
+    std::ofstream bin(bin_path, std::ios::binary);
+    if (!bin.is_open()) return;
+    cereal::PortableBinaryOutputArchive ar(bin);
+
+    ar(static_cast<uint32_t>(bootMap.size()));
+    for (const auto& [slots, precom] : bootMap) {
+        if (!precom) continue;
+        ar(precom->m_slots);
+        ar(static_cast<uint32_t>(precom->m_paramsEnc.g));  // m_dim1
+
+        auto write_params = [&](const auto& p) {
+            ar(p.lvlb, p.layersCollapse, p.remCollapse, p.numRotations,
+               p.b, p.g, p.numRotationsRem, p.bRem, p.gRem);
+        };
+        write_params(precom->m_paramsEnc);
+        write_params(precom->m_paramsDec);
+
+        auto write_2d = [&](const auto& outer) {
+            ar(static_cast<uint32_t>(outer.size()));
+            for (const auto& inner : outer) {
+                ar(static_cast<uint32_t>(inner.size()));
+                for (const auto& pt : inner)
+                    ar(pt->template GetElement<lbcrypto::DCRTPoly>());
+            }
+        };
+        auto write_1d = [&](const auto& vec) {
+            ar(static_cast<uint32_t>(vec.size()));
+            for (const auto& pt : vec)
+                ar(pt->template GetElement<lbcrypto::DCRTPoly>());
+        };
+
+        write_2d(precom->m_U0hatTPreFFT);
+        write_2d(precom->m_U0PreFFT);
+        write_1d(precom->m_U0Pre);
+        write_1d(precom->m_U0hatTPre);
+    }
+    bin.close();
+    std::cout << "[NIOBIUM] Wrote bootstrap precompute: "
+              << bin_path.filename().string() << " + "
+              << ids_path.filename().string() << std::endl;
 }
 
 // ============================================================================

--- a/src/auto_facade.cpp
+++ b/src/auto_facade.cpp
@@ -15,6 +15,7 @@
 #include "cryptocontext-ser.h"
 #include "key/key-ser.h"
 #include "scheme/ckksrns/ckksrns-ser.h"
+#include "scheme/ckksrns/ckksrns-fhe.h"
 
 #include "cereal_io.h"
 #include <cereal/archives/portable_binary.hpp>
@@ -419,6 +420,49 @@ void Compiler::tag_keys<lbcrypto::CryptoContext<DCRTPoly>>(
     } catch (...) {}
 
     std::cout << "[NIOBIUM] Tagged " << total << " key polynomials for replay" << std::endl;
+}
+
+// Capture the CKKS bootstrap precomputation plaintexts so the simulator
+// has their polynomial values as live-in. Walks the FHECKKSRNS private
+// m_bootPrecomMap via its probe-exposed accessor (GetBootPrecomMap), and
+// captures every DCRTPoly inside m_U0Pre / m_U0hatTPre / m_U0PreFFT /
+// m_U0hatTPreFFT as an input under the "bootstrap_precompute" name.
+template<>
+void Compiler::tag_bootstrap_precompute<lbcrypto::CryptoContext<DCRTPoly>>(
+    const lbcrypto::CryptoContext<DCRTPoly>& cc) {
+    if (!cc) return;
+    auto scheme = cc->GetScheme();
+    if (!scheme) return;
+    auto fheBase = scheme->GetFHE();
+    if (!fheBase) return;
+    auto fheCkks = std::dynamic_pointer_cast<lbcrypto::FHECKKSRNS>(fheBase);
+    if (!fheCkks) return;
+
+    const auto& bootMap = fheCkks->GetBootPrecomMap();
+    if (bootMap.empty()) return;
+
+    std::vector<uint64_t> addr_ids;
+    auto capture_pt = [&](const auto& pt) {
+        if (!pt) return;
+        // Plaintext wraps a single DCRTPoly; reuse capture_dcrt_polys.
+        const auto& el = pt->template GetElement<lbcrypto::DCRTPoly>();
+        std::vector<DCRTPoly> one;
+        one.push_back(el);
+        capture_dcrt_polys(*this, "bootstrap_precompute", one, addr_ids);
+    };
+
+    size_t before = addr_ids.size();
+    for (const auto& [slots, precom] : bootMap) {
+        if (!precom) continue;
+        for (const auto& pt : precom->m_U0Pre) capture_pt(pt);
+        for (const auto& pt : precom->m_U0hatTPre) capture_pt(pt);
+        for (const auto& inner : precom->m_U0PreFFT)
+            for (const auto& pt : inner) capture_pt(pt);
+        for (const auto& inner : precom->m_U0hatTPreFFT)
+            for (const auto& pt : inner) capture_pt(pt);
+    }
+    std::cout << "[NIOBIUM] Tagged " << (addr_ids.size() - before)
+              << " bootstrap precompute polynomials" << std::endl;
 }
 
 // ============================================================================

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -685,6 +685,11 @@ void Compiler::write_replay_json() {
         files["evalautomorphism_keys"] = (dir / (prog + ".rk.bin")).string();
         files["evalautomorphism_ids"] = (dir / (prog + ".rk.ids")).string();
     }
+    auto bp_bin = dir / (prog + ".bp.bin");
+    if (std::filesystem::exists(bp_bin)) {
+        files["bootstrap_precomp"] = (prog + ".bp.bin");
+        files["bootstrap_precomp_ids"] = (prog + ".bp.ids");
+    }
 
     replay["files"] = files;
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -410,22 +410,27 @@ bool Compiler::replay() {
     auto rbw_addrs = impl_->simulator->get_read_before_write_addresses();
     std::set<uint64_t> rbw_set(rbw_addrs.begin(), rbw_addrs.end());
 
-    // Populate simulator memory from captured input data (only live-in addresses)
+    // Populate simulator memory from captured input data.
+    //
+    // Load captured polys unconditionally (not only live-in addresses).
+    // Rationale: inputs like bootstrap-precompute plaintexts are typically
+    // *cloned* before being consumed by the trace; the clone's address is
+    // the one that ends up live-in, and the data-parent chain carries data
+    // from the captured original to the clone. If we skip non-live-in
+    // captures here, the parent is never materialized and propagation
+    // cannot reach the clone.
     size_t direct_count = 0;
     for (const auto& input : impl_->captured_inputs) {
-        size_t loaded = 0, skipped = 0;
+        size_t live = 0, aux = 0;
         for (const auto& elem : input.elements) {
-            if (rbw_set.count(elem.addr_id)) {
-                impl_->simulator->store_polynomial(elem.addr_id, elem.values, elem.modulus);
-                direct_count++;
-                loaded++;
-            } else {
-                skipped++;
-            }
+            impl_->simulator->store_polynomial(elem.addr_id, elem.values, elem.modulus);
+            direct_count++;
+            if (rbw_set.count(elem.addr_id)) ++live;
+            else ++aux;
         }
         std::cout << "[NIOBIUM]   " << input.name << ": "
                   << input.elements.size() << " elements, "
-                  << loaded << " loaded, " << skipped << " skipped (not live-in)"
+                  << live << " live-in, " << aux << " aux (for parent chain)"
                   << std::endl;
     }
 
@@ -493,6 +498,28 @@ bool Compiler::replay() {
                           << std::endl;
             }
         }
+    }
+
+    // Debug: dump unloaded live-in addresses + a sample of captured non-live-in.
+    if (std::getenv("NIOBIUM_DEBUG_ADDRS") && !unloaded.empty()) {
+        std::sort(unloaded.begin(), unloaded.end());
+        std::set<uint64_t> captured_addrs;
+        for (const auto& input : impl_->captured_inputs)
+            for (const auto& e : input.elements)
+                captured_addrs.insert(e.addr_id);
+        std::cout << "[NIOBIUM-DBG] unloaded live-in: min=" << unloaded.front()
+                  << " max=" << unloaded.back() << " count=" << unloaded.size()
+                  << std::endl;
+        std::cout << "[NIOBIUM-DBG] captured addrs: ";
+        std::vector<uint64_t> sorted_cap(captured_addrs.begin(), captured_addrs.end());
+        std::sort(sorted_cap.begin(), sorted_cap.end());
+        if (!sorted_cap.empty())
+            std::cout << "min=" << sorted_cap.front() << " max=" << sorted_cap.back()
+                      << " count=" << sorted_cap.size();
+        std::cout << std::endl;
+        size_t overlap = 0;
+        for (uint64_t a : unloaded) if (captured_addrs.count(a)) ++overlap;
+        std::cout << "[NIOBIUM-DBG] unloaded ∩ captured = " << overlap << std::endl;
     }
 
     std::cout << "[NIOBIUM] Live-in: " << rbw_set.size()


### PR DESCRIPTION
## Summary

First step toward getting the CKKS bootstrap test end-to-end green. Adds the client-side infrastructure to match what the compiler produces under `cipher_ops_server_wl_0_op_*/.bp.*`, plus the machinery needed for the simulator to see the precomputed plaintexts.

### Changes

**1. New public API: `Compiler::tag_bootstrap_precompute(cc)`**

Walks `FHECKKSRNS::GetBootPrecomMap()` (exposed via the probe-gated accessor in vendored OpenFHE) and captures every DCRTPoly inside
- `m_U0hatTPreFFT` (2D),
- `m_U0PreFFT` (2D),
- `m_U0Pre` (1D),
- `m_U0hatTPre` (1D).

Traversal order matches the compiler's `record_bootstrap_precomp` so the .ids file lines up.

**2. On-disk serialization**

Each call now emits:
- `<prog>.bp.bin` — cereal `PortableBinaryOutputArchive` with per-slot metadata (slots, dim1, `paramsEnc`/`paramsDec` as 9 int fields each) plus the DCRTPoly contents of all four vectors. Byte-for-byte compatible with `CerealIO::write_bootstrap_precomp`.
- `<prog>.bp.ids` — flat `[count][addr_id₀][addr_id₁]...` uint64 file matching the traversal order.

**3. Replay loader**

`replay()` now stores captured inputs **unconditionally** (not gated on the live-in set), so inputs that are only reached through the data-parent chain (e.g. clone → `+=` patterns in bootstrap) propagate correctly to the trace's live-in addresses.

**4. `fhetch_replay.json`**

When `.bp.bin` exists, the `files` block picks it up:
```json
"bootstrap_precomp": "bootstrap_server_workload_ckks_bootstrap.bp.bin",
"bootstrap_precomp_ids": "bootstrap_server_workload_ckks_bootstrap.bp.ids"
```

**5. `examples/bootstrap/`**

- `server.cpp`: tags bootstrap precompute before `start()` so the `.bp.*` files are on disk by the time `stop()` writes `fhetch_replay.json`. Extracts the probe ciphertext and writes `ct_result.bin`. Optional `NIOBIUM_BOOTSTRAP_HOLLOW=0` toggle to force real-math recording.
- Makefile: `test-bootstrap{,-release}` now clears stale workloads and runs `bootstrap_decrypt` as the pass/fail step.

**6. Debug knob**

`NIOBIUM_DEBUG_ADDRS=1` dumps the simulator's live-in vs. captured address overlap at replay time — used to diagnose the remaining gap (see below).

### Status

**Workload directory now matches the compiler's parity set**:

```
bootstrap_server_workload_ckks_bootstrap.bp.bin          (52 MB)
bootstrap_server_workload_ckks_bootstrap.bp.ids          (25 KB, 3204 ids)
bootstrap_server_workload_ckks_bootstrap.mk.bin/.ids
bootstrap_server_workload_ckks_bootstrap.rk.bin/.ids
bootstrap_server_workload_ckks_bootstrap.input_input_cipher.bin/.ids
... fhetch + replay.json + outputs.json ...
```

**Remaining gap** (not fixed in this PR):

```
unloaded live-in:  9774..16331 count=3204
captured addrs:    0..246710   count=12976
unloaded ∩ captured = 0
```

The 3204 trace-referenced FHETCH addresses in the 9774–16331 range don't overlap with any captured poly. These are transient OpenFHE scheme internals — polys constructed during `EvalBootstrapSetup`/`EvalBootstrapKeyGen` that never land in `m_bootPrecomMap` and aren't keys. The compiler avoids this by running an address-compaction + refcounting layer that recycles FHETCH ids for dropped polys and pins known inputs/keys/bootstrap-precompute. Our client's sequential-id allocator assigns a FHETCH id to every poly constructor, so the trace ends up referencing scheme internals we can't reach. A follow-up PR will port a lightweight compaction layer (path A).

### Test plan
- [ ] `make test-bootstrap-release` — produces `.bp.bin` + `.bp.ids`, simulator runs 852 K instructions in ~3 s. Decrypt currently fails (gap above) but the recording pipeline is complete.
- [ ] `ls bootstrap_server_workload_ckks_bootstrap/*.bp.*` — both files present.
- [ ] `grep bootstrap_precomp bootstrap_server_workload_ckks_bootstrap/fhetch_replay.json` — two entries.
- [ ] `NIOBIUM_DEBUG_ADDRS=1 make test-bootstrap-release` — prints live-in vs. captured summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)