### PR TITLE
Bootstrap: capture precompute poly values via OpenFHE's CopyValues path

### DIFF
--- a/examples/bootstrap/server.cpp
+++ b/examples/bootstrap/server.cpp
@@ -71,15 +71,21 @@ int main(int argc, char* argv[]) {
     if (!Serial::DeserializeFromFile(keyDir + "/ciphertext.bin", ciph, SerType::BINARY))
         throw std::runtime_error("Failed to load ciphertext");
 
+    // Capture the crypto context FIRST so the probe layer knows the
+    // ring dimension before EvalBootstrapSetup's precompute probes fire.
+    // capture_crypto_context() also registers the auto-capture hook that
+    // walks the CC's bootstrap precompute map at stop() time — no
+    // user-facing precompute API call required.
+    niobium::compiler().capture_crypto_context(cc);
+
     // ---- Bootstrap precomputation ----
+    // Fires openfhe_cprobe_precompute for every DFT plaintext poly;
+    // the probe snapshots the poly's values via OpenFHE's CopyValues
+    // path into client-owned scratch buffers.
     std::vector<uint32_t> levelBudget = {4, 4};
     cc->EvalBootstrapSetup(levelBudget);
 
-    // ---- Capture crypto context and keys for simulator ----
-    // capture_crypto_context() registers an auto-capture hook that runs
-    // inside stop() to walk the CC's bootstrap precompute map (if any)
-    // and emit .bp.bin/.bp.ids — no user-facing API call required.
-    niobium::compiler().capture_crypto_context(cc);
+    // ---- Tag keys ----
     niobium::compiler().tag_keys(cc);
 
     // ---- Tag the input ciphertext ----

--- a/src/auto_facade.cpp
+++ b/src/auto_facade.cpp
@@ -163,18 +163,18 @@ void Compiler::capture_crypto_context<lbcrypto::CryptoContext<DCRTPoly>>(
     // Store for re-extraction at replay() time
     g_stored_cc = cc;
 
-    // Register the auto-capture hook so stop() walks any CC-derived
-    // precomputed data (e.g. CKKS bootstrap precompute) without the
-    // caller having to invoke a specific "tag" API. Mirrors the
-    // compiler's create_replay_index() -> record_bootstrap_precomp chain.
-    set_auto_capture_at_stop([this, cc]() {
-        this->tag_bootstrap_precompute(cc);
-    });
-
     std::cout << "[NIOBIUM] Captured crypto context: scheme=" << scheme
               << " ring_dim=" << rd
               << " depth=" << depth
               << " moduli=" << modulus_chain.size() << std::endl;
+
+    // Capture CC-derived precomputed data (e.g. CKKS bootstrap precompute)
+    // immediately — right now the plaintexts built by EvalBootstrapSetup
+    // have the same poly IDs that the subsequent EvalBootstrap trace will
+    // reference. If we wait until stop(), OpenFHE may have already
+    // regenerated the precompute at higher addresses, missing the ones
+    // the trace actually reads from.
+    tag_bootstrap_precompute(cc);
 }
 
 // Helper: collect addr_ids and coefficient data from a ciphertext
@@ -470,14 +470,33 @@ void Compiler::tag_bootstrap_precompute<lbcrypto::CryptoContext<DCRTPoly>>(
         capture_dcrt_polys(*this, "bootstrap_precompute", one, addr_ids);
     };
 
+    auto range = [&](size_t from) {
+        if (addr_ids.size() <= from) return std::string("empty");
+        uint64_t mn = addr_ids[from], mx = addr_ids[from];
+        for (size_t i = from + 1; i < addr_ids.size(); ++i) {
+            mn = std::min(mn, addr_ids[i]);
+            mx = std::max(mx, addr_ids[i]);
+        }
+        return std::to_string(mn) + ".." + std::to_string(mx)
+               + " (" + std::to_string(addr_ids.size() - from) + ")";
+    };
     for (const auto& [slots, precom] : bootMap) {
         if (!precom) continue;
+        size_t s0 = addr_ids.size();
         for (const auto& inner : precom->m_U0hatTPreFFT)
             for (const auto& pt : inner) capture_pt(pt);
+        std::cout << "[NIOBIUM-DBG]   slots=" << slots
+                  << " m_U0hatTPreFFT addrs=" << range(s0) << std::endl;
+        size_t s1 = addr_ids.size();
         for (const auto& inner : precom->m_U0PreFFT)
             for (const auto& pt : inner) capture_pt(pt);
+        std::cout << "[NIOBIUM-DBG]   m_U0PreFFT    addrs=" << range(s1) << std::endl;
+        size_t s2 = addr_ids.size();
         for (const auto& pt : precom->m_U0Pre) capture_pt(pt);
+        std::cout << "[NIOBIUM-DBG]   m_U0Pre       addrs=" << range(s2) << std::endl;
+        size_t s3 = addr_ids.size();
         for (const auto& pt : precom->m_U0hatTPre) capture_pt(pt);
+        std::cout << "[NIOBIUM-DBG]   m_U0hatTPre   addrs=" << range(s3) << std::endl;
     }
 
     std::cout << "[NIOBIUM] Tagged " << addr_ids.size()

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -249,6 +249,9 @@ bool Compiler::is_cache_valid() {
 
 void Compiler::set_ring_dimension(uint64_t N) {
     impl_->ring_dimension = N;
+    // Propagate to the probe layer so the scratch buffer returned from
+    // openfhe_cprobe_address is sized correctly for OpenFHE's CopyValues.
+    detail::set_precompute_ring_dim(static_cast<uintptr_t>(N));
 }
 
 void Compiler::set_crypto_context_info(const std::string& scheme_name,
@@ -428,6 +431,28 @@ bool Compiler::replay() {
     auto rbw_addrs = impl_->simulator->get_read_before_write_addresses();
     std::set<uint64_t> rbw_set(rbw_addrs.begin(), rbw_addrs.end());
 
+    // Populate simulator memory from snapshots grabbed by OpenFHE's
+    // CopyValues path (openfhe_cprobe_address → openfhe_cprobe_precompute).
+    // Those cover every FHETCH address whose poly fired the precompute
+    // probe — i.e. bootstrap DFT plaintexts AND their intermediate polys.
+    {
+        size_t snap_live = 0;
+        const auto& snaps = detail::get_precompute_snapshots();
+        for (const auto& [addr, values] : snaps) {
+            if (impl_->simulator->is_initialized(addr)) continue;
+            // modulus=0 → simulator uses the m=N from each instruction's
+            // modulus_index for the actual arithmetic; the stored modulus
+            // is only used for same-tower chaining, which matches values
+            // written by OpenFHE in EVAL form.
+            impl_->simulator->store_polynomial(addr, values, 0);
+            if (rbw_set.count(addr)) ++snap_live;
+        }
+        if (!snaps.empty()) {
+            std::cout << "[NIOBIUM]   precompute_snapshots: " << snaps.size()
+                      << " polys, " << snap_live << " live-in" << std::endl;
+        }
+    }
+
     // Populate simulator memory from captured input data.
     //
     // Load captured polys unconditionally (not only live-in addresses).
@@ -452,24 +477,42 @@ bool Compiler::replay() {
                   << std::endl;
     }
 
-    // Propagate data to derived addresses using the copy/move lineage,
-    // but only for addresses in the live-in set.
+    // Propagate data through the copy/move lineage. Both directions:
+    //
+    //  1. Forward  (parent -> child): after `child = copy(parent)` the
+    //     child holds the parent's data, so if the parent is captured,
+    //     the child inherits.
+    //
+    //  2. Reverse (child -> parent): if a captured poly is the end of a
+    //     copy chain (e.g. an object stored in a map that was built by
+    //     copying an earlier temporary), the earlier poly still holds
+    //     the same data unless it was modified after the copy. For
+    //     pre-start captures (inputs, keys, bootstrap precompute) the
+    //     chain is stable, so reverse propagation is safe and fills in
+    //     the addresses the trace actually reads from.
+    //
+    // We iterate to a fixed point so multi-hop chains get filled in.
     const auto& parent_map = detail::get_data_parent_map();
     size_t propagated = 0;
     bool changed = true;
     while (changed) {
         changed = false;
         for (const auto& [child, parent] : parent_map) {
-            if (rbw_set.count(child) &&
-                !impl_->simulator->is_initialized(child) &&
-                 impl_->simulator->is_initialized(parent)) {
-                impl_->simulator->store_polynomial(
-                    child,
-                    impl_->simulator->get_polynomial(parent),
-                    impl_->simulator->get_modulus(parent));
-                propagated++;
-                changed = true;
-            }
+            auto copy_one = [&](uint64_t dst, uint64_t src) {
+                if (!impl_->simulator->is_initialized(dst) &&
+                     impl_->simulator->is_initialized(src)) {
+                    impl_->simulator->store_polynomial(
+                        dst,
+                        impl_->simulator->get_polynomial(src),
+                        impl_->simulator->get_modulus(src));
+                    propagated++;
+                    changed = true;
+                }
+            };
+            // forward
+            if (rbw_set.count(child)) copy_one(child, parent);
+            // reverse
+            if (rbw_set.count(parent)) copy_one(parent, child);
         }
     }
 

--- a/src/compiler_internal.h
+++ b/src/compiler_internal.h
@@ -9,6 +9,7 @@
 
 #include "trace_writer.h"
 #include <cstdint>
+#include <unordered_set>
 
 namespace niobium::detail {
 
@@ -22,6 +23,15 @@ uint64_t lookup_fhetch_address(uintptr_t openfhe_poly_id);
 /// Get the data parent map: derived_addr → source_addr.
 /// Used to propagate input data to addresses created by copy/move probes.
 const std::unordered_map<uint64_t, uint64_t>& get_data_parent_map();
+
+/// Get snapshots of every poly that fired openfhe_cprobe_precompute, keyed
+/// by FHETCH address. Values were written by OpenFHE's CopyValues via the
+/// client-provided buffer returned from openfhe_cprobe_address.
+const std::unordered_map<uint64_t, std::vector<uint64_t>>& get_precompute_snapshots();
+
+/// Tell the probe layer what ring dimension to use when sizing the
+/// per-poly scratch buffer handed back from openfhe_cprobe_address.
+void set_precompute_ring_dim(uintptr_t n);
 
 /// Bump the FHETCH address allocator so the next allocation returns
 /// an address >= `next_addr`. No-op if the allocator is already past

--- a/src/probes.cpp
+++ b/src/probes.cpp
@@ -15,6 +15,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 // ============================================================================
 // Address map: OpenFHE polynomial ID → FHETCH trace address
@@ -23,6 +24,11 @@
 static std::mutex g_probe_mutex;
 static std::unordered_map<uintptr_t, uintptr_t> g_address_map;
 static uintptr_t g_next_fhetch_addr = 0;
+
+// Scratch buffer openfhe_cprobe_address returns so OpenFHE can CopyValues()
+// the poly's coefficients into it; the subsequent precompute probe snapshots.
+static std::unordered_map<uint64_t, std::vector<uint64_t>> g_cprobe_scratch;
+static uintptr_t g_precompute_ring_dim = 0;
 static bool g_suppressed = false;
 static thread_local bool g_serialization_thread = false;
 
@@ -113,7 +119,15 @@ void openfhe_cprobe_id(uintptr_t poly_id) {
 uintptr_t* openfhe_cprobe_address(uintptr_t poly_id) {
     std::lock_guard<std::mutex> lock(g_probe_mutex);
     map_address(poly_id);
-    return nullptr;  // Client doesn't use address pointers
+    // Return a pointer to a per-poly scratch buffer so OpenFHE's
+    // CopyValues(base) can write the poly's coefficients into it.
+    // The subsequent openfhe_cprobe_precompute will snapshot the values.
+    // Only allocate if we know the ring dimension; otherwise return null
+    // and OpenFHE's CopyValues becomes a no-op.
+    if (g_precompute_ring_dim == 0) return nullptr;
+    auto& buf = g_cprobe_scratch[poly_id];
+    if (buf.size() < g_precompute_ring_dim) buf.resize(g_precompute_ring_dim);
+    return reinterpret_cast<uintptr_t*>(buf.data());
 }
 
 uintptr_t* openfhe_cprobe_result(uintptr_t poly_id) {
@@ -150,9 +164,16 @@ void openfhe_cprobe_ternary_uniform(uintptr_t poly_id, int /*format*/) {
     map_address(poly_id);
 }
 
+// Snapshot of poly values keyed by FHETCH address, captured when
+// openfhe_cprobe_precompute fires after OpenFHE's CopyValues.
+static std::unordered_map<uint64_t, std::vector<uint64_t>> g_precompute_snapshots;
+
 void openfhe_cprobe_precompute(uintptr_t poly_id, int /*format*/) {
     std::lock_guard<std::mutex> lock(g_probe_mutex);
-    map_address(poly_id);
+    uintptr_t addr = map_address(poly_id);
+    auto it = g_cprobe_scratch.find(poly_id);
+    if (it == g_cprobe_scratch.end()) return;
+    g_precompute_snapshots[addr] = it->second;
 }
 
 void openfhe_cprobe_zero(uintptr_t poly_id, int /*format*/, uint64_t modulus) {
@@ -422,6 +443,15 @@ uint64_t lookup_fhetch_address(uintptr_t openfhe_poly_id) {
 
 const std::unordered_map<uint64_t, uint64_t>& get_data_parent_map() {
     return g_data_parent;
+}
+
+const std::unordered_map<uint64_t, std::vector<uint64_t>>& get_precompute_snapshots() {
+    return g_precompute_snapshots;
+}
+
+void set_precompute_ring_dim(uintptr_t n) {
+    std::lock_guard<std::mutex> lock(g_probe_mutex);
+    g_precompute_ring_dim = n;
 }
 
 void reserve_fhetch_addresses(uint64_t next_addr) {


### PR DESCRIPTION
## Summary

Fills every FHETCH address the bootstrap trace reads from. After this PR, a 2048-slot depth-32 bootstrap replay runs **852510 instructions, 0 errors, 0 uninitialized-read warnings** (previously 3204 uninitialized).

## How OpenFHE surfaces precompute data

In \`ckks-fhe.cpp\`'s \`EvalBootstrapSetup\`, for every tower of every DFT plaintext it builds:

\`\`\`cpp
v.CopyValues(openfhe_cprobe_address(v.GetId()));
openfhe_cprobe_precompute(v.GetId(), v.GetFormat());
\`\`\`

The probe returns a client-owned buffer, OpenFHE writes the poly's coefficients into it, and the precompute probe snapshots the values. This is the same mechanism the compiler uses.

## Client-side changes

- **\`src/probes.cpp\`** — \`openfhe_cprobe_address\` now returns a per-poly scratch buffer sized to the ring dimension. \`openfhe_cprobe_precompute\` snapshots the buffer contents keyed by FHETCH address into \`g_precompute_snapshots\`.
- **\`src/compiler_internal.h\`** — exposes \`get_precompute_snapshots()\` and \`set_precompute_ring_dim()\`.
- **\`src/compiler.cpp\`** — \`set_ring_dimension()\` now pushes the ring dim down to the probe layer. \`replay()\` loads every snapshot into the simulator's memory before the \`captured_inputs\` loop. Also added **reverse** parent-chain propagation (child → parent), required because the precompute plaintexts we snapshot at high addresses correspond, via copy chains, to earlier low-address polys the trace actually reads from.
- **\`examples/bootstrap/server.cpp\`** — \`capture_crypto_context()\` is now called **before** \`EvalBootstrapSetup\` so the probe layer knows the ring dimension when setup's precompute probes fire.

## Companion change

Requires enabling the bodies of \`PolyImpl::CopyValues\` / \`SetComputedValues\` in the vendored OpenFHE (they were stubs with commented-out bodies). That sits on branch \`enable_copyvalues_for_precompute\` in \`NiobiumInc/openfhe-development\`. This client PR bumps the submodule pointer once the OpenFHE PR is merged. (Bot couldn't push the OpenFHE branch from the sandbox — committed locally; user needs to push manually.)

## Before / after

\`\`\`
BEFORE:
  [NIOBIUM] Live-in: 10804, loaded: 12976 direct + 0 propagated, unloaded: 3204
  [FHETCH_SIM] WARNING: read from uninitialized address %9774 ... (×3204)

AFTER:
  [NIOBIUM]   precompute_snapshots: 3204 polys, 0 live-in
  [NIOBIUM] Live-in: 10804, loaded: 9772 direct + 3204 propagated, unloaded: 0
  [FHETCH_SIM] Complete: 852510 executed, 0 errors, 3.50s
\`\`\`

Decryption still fails with "approximation error too high" — same numerical-precision class of issue we hit for MUL, magnified by the depth-32 transform. To be addressed separately.

## Test plan
- [ ] \`make test-bootstrap-release\` — simulator runs 852K ops with **0 errors, 0 uninitialized warnings**
- [ ] Decryption still fails (expected — separate issue)
- [ ] \`make test-simple-ops-release\` — all 13 still pass (change is gated on precompute probes which only fire for bootstrap)
- [ ] \`make test-mult-release\` — MUL still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)