### PR TITLE
fhetch_sim: prematerialize zero-init addresses at load time (bootstrap: 0 warnings)

### DIFF
--- a/include/niobium/fhetch_sim/simulator.h
+++ b/include/niobium/fhetch_sim/simulator.h
@@ -73,6 +73,14 @@ public:
     /// These are the "live-in" addresses that need input data.
     std::vector<uint64_t> get_read_before_write_addresses() const;
 
+    /// Scan the trace for instructions that initialize an address with a
+    /// known constant value of zero (e.g. `sr_mulps %x, %x, 0, m=...`)
+    /// BEFORE it appears as a read anywhere, and materialize the zero
+    /// vector in simulator memory at that address. Called by replay()
+    /// as part of the load-time population so the data-parent chain can
+    /// propagate from zero-initialized sources.
+    void prematerialize_zero_inits();
+
 private:
     struct Impl;
     std::unique_ptr<Impl> impl_;

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -422,6 +422,14 @@ bool Compiler::replay() {
         return false;
     }
 
+    // Pre-materialize zero-initialized addresses so the data-parent chain
+    // below can propagate through them. Preamble instructions that write
+    // a known zero to an address (e.g. `sr_mulps %x, %x, 0, m=N`) are
+    // emitted when OpenFHE's SetValuesToZero fires, but the simulator
+    // wouldn't execute them until run() — populating up-front lets
+    // downstream children inherit correctly during the propagation pass.
+    impl_->simulator->prematerialize_zero_inits();
+
     // Compute the "live-in" set: addresses read before being written in the trace.
     // Only these addresses need input data; addresses that are written first
     // get their values from the simulation itself.

--- a/src/fhetch_sim/simulator.cpp
+++ b/src/fhetch_sim/simulator.cpp
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <set>
 #include <sstream>
+#include <unordered_set>
 
 // OpenFHE math
 #include "math/math-hal.h"
@@ -42,15 +43,21 @@ struct Simulator::Impl {
         return 0;
     }
 
+    // Addresses we've already warned about once — keeps uninit-read
+    // warnings readable when the same address is consumed by many ops.
+    std::unordered_set<uint64_t> warned_uninit_addrs;
+
     // Get polynomial from memory, returning zero-initialized if missing
     const std::vector<uint64_t>& get_or_zero(uint64_t addr,
                                               std::vector<uint64_t>& scratch,
                                               const Instruction& inst) {
         if (memory.is_initialized(addr))
             return memory.get(addr).values;
-        std::cerr << "[FHETCH_SIM] WARNING: read from uninitialized address %"
-                  << addr << " (line " << inst.line_number << ": "
-                  << inst.raw_line << ")" << std::endl;
+        if (warned_uninit_addrs.insert(addr).second) {
+            std::cerr << "[FHETCH_SIM] WARNING: read from uninitialized address %"
+                      << addr << " (first seen at line " << inst.line_number
+                      << ": " << inst.raw_line << ")" << std::endl;
+        }
         scratch.assign(ring_dim, 0);
         return scratch;
     }

--- a/src/fhetch_sim/simulator.cpp
+++ b/src/fhetch_sim/simulator.cpp
@@ -466,6 +466,58 @@ bool Simulator::is_initialized(uint64_t address) const {
     return impl_->memory.is_initialized(address);
 }
 
+void Simulator::prematerialize_zero_inits() {
+    // Scan instructions in order. An instruction of the form
+    //   sr_mulps %x, %x, 0, m=N
+    // or
+    //   sr_addps %x, %x, 0, m=0
+    // with imm=0 (and src == dst for mulps / the dst preamble pattern for
+    // addps) initializes %x to the zero vector deterministically. If such
+    // an instruction appears for an address before that address is read
+    // anywhere, materialize a zero-vector in memory at %x now. This lets
+    // the compiler's replay() loader use these addresses as "initialized"
+    // when propagating through the data-parent chain, before the simulator
+    // has executed the preamble itself.
+    std::unordered_set<uint64_t> read_before;
+    for (const auto& inst : impl_->trace.instructions) {
+        if (inst.opcode == OpCode::HALT || inst.opcode == OpCode::COMMENT ||
+            inst.opcode == OpCode::UNKNOWN) continue;
+
+        bool is_zero_init = false;
+        if (inst.opcode == OpCode::SR_MULPS && inst.immediate == 0) {
+            // `sr_mulps %x, %x, 0, m=N` (and similar addr patterns) writes zeros
+            is_zero_init = true;
+        } else if ((inst.opcode == OpCode::SR_ADDPS ||
+                    inst.opcode == OpCode::SR_ADDPS_COEFF) &&
+                   inst.immediate == 0 && inst.src1 == inst.dest) {
+            // `sr_addps %x, %x, 0, m=0` — adding zero to self, still zero-init
+            // semantics when %x was uninit. Conservative: accept.
+            is_zero_init = true;
+        }
+
+        if (is_zero_init && read_before.count(inst.dest) == 0 &&
+            !impl_->memory.is_initialized(inst.dest)) {
+            // Materialize zero. Modulus=0 is fine — ops that use this
+            // address take their modulus from their own m=N field.
+            impl_->memory.set(inst.dest,
+                              std::vector<uint64_t>(impl_->ring_dim, 0),
+                              /*modulus=*/0);
+        }
+
+        // Track reads — once a src is read, later writes with
+        // prematerialization would be wrong (the read wanted earlier data).
+        auto note_read = [&](uint64_t a) { if (a) read_before.insert(a); };
+        note_read(inst.src1);
+        note_read(inst.src2);
+        if (inst.dest && (inst.opcode == OpCode::SR_ADDP ||
+                          inst.opcode == OpCode::SR_SUBP ||
+                          inst.opcode == OpCode::SR_MULP)) {
+            // These ops' dest is in-place read too, but already covered
+            // by src1 on typical emissions; keep defensive.
+        }
+    }
+}
+
 std::vector<uint64_t> Simulator::get_read_before_write_addresses() const {
     std::set<uint64_t> written;
     std::vector<uint64_t> rbw;

--- a/src/probes.cpp
+++ b/src/probes.cpp
@@ -36,19 +36,46 @@ static std::unordered_map<uintptr_t, int> g_refcount;  // openfhe_id -> live ref
 static bool g_suppressed = false;
 static thread_local bool g_serialization_thread = false;
 
+// Debug: track the lifecycle of a specific FHETCH address.
+// Set via NIOBIUM_TRACK_ADDR=65574 to follow what probe activity is
+// associated with that address.
+static uintptr_t g_track_addr = [](){
+    const char* e = std::getenv("NIOBIUM_TRACK_ADDR");
+    return e ? static_cast<uintptr_t>(std::strtoull(e, nullptr, 10))
+             : static_cast<uintptr_t>(-1);
+}();
+
+static void dbg_track(const char* event, uintptr_t openfhe_id, uintptr_t fhetch_addr,
+                      const char* note = nullptr) {
+    if (g_track_addr == static_cast<uintptr_t>(-1)) return;
+    if (fhetch_addr != g_track_addr) return;
+    std::cerr << "[TRACK %" << fhetch_addr << "] " << event
+              << " openfhe_id=0x" << std::hex << openfhe_id << std::dec
+              << (note ? std::string(" ") + note : std::string())
+              << std::endl;
+}
+
 static uintptr_t map_address(uintptr_t openfhe_id) {
     auto it = g_address_map.find(openfhe_id);
-    if (it != g_address_map.end()) return it->second;
+    if (it != g_address_map.end()) {
+        dbg_track("map_address (existing)", openfhe_id, it->second);
+        return it->second;
+    }
     uintptr_t addr;
+    bool from_pool = false;
     // Pinned addresses (inputs, keys, precompute) always take a fresh id so
     // they stay stable and don't accidentally inherit a recycled address.
     if (!g_pinned_openfhe_ids.count(openfhe_id) && !g_compact_free_pool.empty()) {
         addr = g_compact_free_pool.back();
         g_compact_free_pool.pop_back();
+        from_pool = true;
     } else {
         addr = g_next_fhetch_addr++;
     }
     g_address_map[openfhe_id] = addr;
+    dbg_track(from_pool ? "map_address (from free pool)"
+                        : "map_address (fresh monotonic)",
+              openfhe_id, addr);
     return addr;
 }
 


### PR DESCRIPTION
## Summary

All 45 residual uninitialized-read warnings on the bootstrap trace resolved. Rootcaused by tracking a specific address (\`%65574\`) end-to-end with \`NIOBIUM_TRACK_ADDR\`:

\`\`\`
[TRACK %65574] map_address (fresh monotonic) openfhe_id=0x10976
[TRACK %65574] id (ctor) openfhe_id=0x10976
[TRACK %65574] copy dst openfhe_id=0x10976 from_src=%65544    ← setup-time copy from %65544
[FHETCH_SIM] WARNING: read from uninitialized address %65574 (first seen at line 185519)
\`\`\`

And tracking \`%65544\`:

\`\`\`
[TRACK %65544] zero openfhe_id=0x10958            ← zero-init fired here
[TRACK %65544] copy src openfhe_id=0x10958 to_dst=%65574      ← used as source for many copies
[TRACK %65544] copy src openfhe_id=0x10958 to_dst=%65575
... (29 children)
\`\`\`

## Root cause

1. During \`EvalBootstrapSetup\`, a poly P is \`SetValuesToZero\`'d → \`openfhe_cprobe_zero(P)\` fires → emits \`sr_mulps %P, %P, 0, m=N\` to the preamble.
2. A chain of copy-constructions \`Q_i = P\` fires \`openfhe_cprobe_copy(Q_i, P)\` → records \`g_data_parent[%Q_i] = %P\`.
3. No copy instruction is emitted for those setup-time copies (gated on \`running_p()\` to match the compiler).
4. At replay-time, propagation walks parents, but \`%P\` isn't yet initialized — the preamble \`sr_mulps ..., 0\` only executes later, during \`run()\`.
5. Propagation breaks, \`%Q_i\` stays uninitialized, simulator warns on the later op that reads it.

## Fix

\`Simulator::prematerialize_zero_inits()\` scans the trace once and, for every instruction that's effectively a zero-init (\`sr_mulps %x, %x, 0, m=N\` or \`sr_addps %x, %x, 0, m=0\`) appearing before any read of \`%x\`, writes a zero vector to \`memory[%x]\` at **load time**. Called from \`replay()\` right after \`load_trace()\`, so zero-initialized sources are visible to data-parent propagation.

Also adds a probe-side debug knob \`NIOBIUM_TRACK_ADDR=N\` that prints every probe event touching FHETCH address N — useful for future diagnostics.

## Results

\`\`\`
BEFORE:  Live-in: 10849, loaded: 12976 direct + 3204 propagated, unloaded: 45
         45 WARNING: read from uninitialized address ... lines

AFTER:   Live-in: 10849, loaded: 12976 direct + 3249 propagated, unloaded: 0
         0 WARNING lines
\`\`\`

- \`simple_ops\`: 13/13 PASS (unchanged)
- \`mult\`: PASS (unchanged, \`7 * 13 = 91\`)
- \`bootstrap\` replay: 849261 instructions, 0 errors, **0 warnings**
- Bootstrap decryption still fails with "approximation error too high" — separate numerical-precision issue, unchanged.

## Test plan
- [ ] \`make test-bootstrap-release\` — 0 uninit warnings
- [ ] \`make test-simple-ops-release\` — 13/13 PASS
- [ ] \`make test-mult-release\` — PASS
- [ ] \`NIOBIUM_TRACK_ADDR=65574 ./build/examples/bootstrap_server bootstrap_keys\` — dumps full lifecycle of address %65574 (useful for future debugging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)