### PR TITLE
bootstrap/server.cpp: reorder loads to match compiler's -O0 address layout

### DIFF
--- a/examples/bootstrap/server.cpp
+++ b/examples/bootstrap/server.cpp
@@ -43,6 +43,14 @@ int main(int argc, char* argv[]) {
     std::cout << "=== CKKS Bootstrap — Server ===" << std::endl;
     std::cout << "Loading keys from: " << keyDir << std::endl;
 
+    // Mirrors the order of niobium-compiler/examples/simple-ckks-bootstrapping.cpp:
+    // load cc, then keys, then input ciphertext, then EvalBootstrapSetup,
+    // then capture_crypto_context, then tag_input. The compiler's compaction
+    // layer then lays out addresses as inputs -> mk -> rk -> bp (inputs at
+    // low addrs). Our client allocates addresses at poly-construction time,
+    // so to mirror that layout we reserve a small input range up front and
+    // let the rest cascade naturally.
+
     // ---- Load crypto context ----
     CryptoContext<DCRTPoly> cc;
     if (!Serial::DeserializeFromFile(keyDir + "/cc.bin", cc, SerType::BINARY))
@@ -50,6 +58,16 @@ int main(int argc, char* argv[]) {
 
     usint ringDim = cc->GetRingDimension();
     std::cout << "Ring dimension: " << ringDim << std::endl;
+
+    // ---- Reserve addresses 1..4 for the input ciphertext (inputs come
+    // first in the compiler's layout; our monotonic allocator matches this
+    // if we carve out the first slot and load the ciphertext before keys). ----
+    niobium::compiler().reserve_addresses(1);
+
+    // ---- Load ciphertext BEFORE keys so its polys get low addresses ----
+    Ciphertext<DCRTPoly> ciph;
+    if (!Serial::DeserializeFromFile(keyDir + "/ciphertext.bin", ciph, SerType::BINARY))
+        throw std::runtime_error("Failed to load ciphertext");
 
     // ---- Load keys ----
     std::cout << "Loading eval mult key..." << std::endl;
@@ -66,27 +84,17 @@ int main(int argc, char* argv[]) {
             throw std::runtime_error("Failed to load eval automorphism keys");
     }
 
-    // ---- Load ciphertext ----
-    Ciphertext<DCRTPoly> ciph;
-    if (!Serial::DeserializeFromFile(keyDir + "/ciphertext.bin", ciph, SerType::BINARY))
-        throw std::runtime_error("Failed to load ciphertext");
-
-    // Capture the crypto context; this registers the auto-capture hook
-    // that will walk the CC's bootstrap precompute map at stop() time —
-    // no user-facing precompute API call required.
-    niobium::compiler().capture_crypto_context(cc);
-
-    // ---- Bootstrap precomputation ----
-    // Fires openfhe_cprobe_precompute for every DFT plaintext poly,
-    // which pins their compact FHETCH addresses against recycling.
+    // ---- Bootstrap precomputation (fires precompute probes) ----
     std::vector<uint32_t> levelBudget = {4, 4};
     cc->EvalBootstrapSetup(levelBudget);
 
-    // ---- Tag keys ----
-    niobium::compiler().tag_keys(cc);
-
-    // ---- Tag the input ciphertext ----
+    // ---- Capture crypto context and tag inputs/keys ----
+    // capture_crypto_context() registers the auto-capture hook that walks
+    // the CC's bootstrap precompute map at stop() time — no user-facing
+    // precompute API call required.
+    niobium::compiler().capture_crypto_context(cc);
     niobium::compiler().tag_input("input_cipher", ciph);
+    niobium::compiler().tag_keys(cc);
 
     // Hollow mode skips OpenFHE's real math during recording, which is fast
     // but leaves intermediate polys uninitialized for the simulator.


### PR DESCRIPTION
## Summary

Reorders the bootstrap server's loads to line up with the compiler example's order (\`simple-ckks-bootstrapping.cpp\`). Three of four live-in address ranges now match the compiler at -O0 exactly.

## Change

Added \`reserve_addresses(1)\` before any load and moved ciphertext load ahead of the keys:

\`\`\`cpp
niobium::compiler().reserve_addresses(1);
// input ciphertext first -> addresses 1..4
Serial::DeserializeFromFile(keyDir + "/ciphertext.bin", ciph, ...);
// then keys
DeserializeEvalMultKey(...);          // mk -> 5..268
DeserializeEvalAutomorphismKey(...);  // rk -> 269..9772
// then bootstrap setup + tags
cc->EvalBootstrapSetup({4,4});
capture_crypto_context(cc);
tag_input("input_cipher", ciph);
tag_keys(cc);
\`\`\`

## Result

| Range | Client | Compiler -O0 |
|---|---|---|
| input_cipher | **1..4** | **1..4** — matches |
| mk | **5..268** | **5..268** — matches |
| rk | **269..9772** | **269..9772** — matches |
| bp | 233506..236709 | 9773..12976 — still higher |

The remaining bp gap is compaction-level: \`EvalBootstrapSetup\` internally allocates ~220K intermediate polys whose compact ids the compiler's Generator recycles. Our monotonic allocator keeps them, so the bootstrap precompute plaintexts land at the top of the map. Closing that gap needs recycling on destruction or lazy mapping — separate follow-up.

## Test plan
- [ ] \`make test-bootstrap-release\` — replay runs 849261 instructions, 0 errors, 0 uninit warnings
- [ ] \`make test-simple-ops-release\` — 13/13 PASS
- [ ] \`make test-mult-release\` — PASS
- [ ] \`.ids\` files byte-compared against compiler-O0 reference for input/mk/rk ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)