### PR TITLE
Lazy FHETCH address allocation (bootstrap layout now matches compiler -O0)

### DIFF
--- a/examples/bootstrap/server.cpp
+++ b/examples/bootstrap/server.cpp
@@ -43,13 +43,11 @@ int main(int argc, char* argv[]) {
     std::cout << "=== CKKS Bootstrap — Server ===" << std::endl;
     std::cout << "Loading keys from: " << keyDir << std::endl;
 
-    // Mirrors the order of niobium-compiler/examples/simple-ckks-bootstrapping.cpp:
-    // load cc, then keys, then input ciphertext, then EvalBootstrapSetup,
-    // then capture_crypto_context, then tag_input. The compiler's compaction
-    // layer then lays out addresses as inputs -> mk -> rk -> bp (inputs at
-    // low addrs). Our client allocates addresses at poly-construction time,
-    // so to mirror that layout we reserve a small input range up front and
-    // let the rest cascade naturally.
+    // Mirrors the order of the compiler's simple-ckks-bootstrapping.cpp.
+    // Address allocation is lazy (compact_address-style), so the loading
+    // order no longer matters for the resulting FHETCH id layout — only
+    // the order of tag_* calls does. Inputs → keys → precompute gives the
+    // same id layout the compiler produces under -O0.
 
     // ---- Load crypto context ----
     CryptoContext<DCRTPoly> cc;
@@ -58,16 +56,6 @@ int main(int argc, char* argv[]) {
 
     usint ringDim = cc->GetRingDimension();
     std::cout << "Ring dimension: " << ringDim << std::endl;
-
-    // ---- Reserve addresses 1..4 for the input ciphertext (inputs come
-    // first in the compiler's layout; our monotonic allocator matches this
-    // if we carve out the first slot and load the ciphertext before keys). ----
-    niobium::compiler().reserve_addresses(1);
-
-    // ---- Load ciphertext BEFORE keys so its polys get low addresses ----
-    Ciphertext<DCRTPoly> ciph;
-    if (!Serial::DeserializeFromFile(keyDir + "/ciphertext.bin", ciph, SerType::BINARY))
-        throw std::runtime_error("Failed to load ciphertext");
 
     // ---- Load keys ----
     std::cout << "Loading eval mult key..." << std::endl;
@@ -84,14 +72,19 @@ int main(int argc, char* argv[]) {
             throw std::runtime_error("Failed to load eval automorphism keys");
     }
 
+    // ---- Load input ciphertext ----
+    Ciphertext<DCRTPoly> ciph;
+    if (!Serial::DeserializeFromFile(keyDir + "/ciphertext.bin", ciph, SerType::BINARY))
+        throw std::runtime_error("Failed to load ciphertext");
+
     // ---- Bootstrap precomputation (fires precompute probes) ----
     std::vector<uint32_t> levelBudget = {4, 4};
     cc->EvalBootstrapSetup(levelBudget);
 
-    // ---- Capture crypto context and tag inputs/keys ----
-    // capture_crypto_context() registers the auto-capture hook that walks
-    // the CC's bootstrap precompute map at stop() time — no user-facing
-    // precompute API call required.
+    // ---- Capture crypto context and tag inputs/keys in the order we
+    // want them laid out in the FHETCH address space ----
+    // capture_crypto_context() also registers the auto-capture hook that
+    // walks the CC's bootstrap precompute map at stop() time.
     niobium::compiler().capture_crypto_context(cc);
     niobium::compiler().tag_input("input_cipher", ciph);
     niobium::compiler().tag_keys(cc);

--- a/examples/mult/server.cpp
+++ b/examples/mult/server.cpp
@@ -47,24 +47,14 @@ int main(int argc, char* argv[]) {
 
     std::cout << "Ring dimension: " << cc->GetRingDimension() << std::endl;
 
-    // Compiler-matching FHETCH address layout:
-    //   1..24    — inputs / scratch (ct_a, ct_b, plus reserved slots)
-    //   25..48   — evalmult keys
-    //   49..     — evalautomorphism keys
-    // OpenFHE polynomials get a FHETCH address the moment they are
-    // constructed (during deserialization), so we must interleave
-    // reserve_addresses() calls with the deserialization order.
-    niobium::compiler().reserve_addresses(1);
-
-    // ---- Load ciphertexts (consume low addresses 1..16) ----
+    // ---- Load ciphertexts (poly IDs allocated; addresses assigned at tag time) ----
     Ciphertext<DCRTPoly> ct_a, ct_b;
     if (!Serial::DeserializeFromFile(keyDir + "/ct_a.bin", ct_a, SerType::BINARY))
         throw std::runtime_error("Failed to load ciphertext a");
     if (!Serial::DeserializeFromFile(keyDir + "/ct_b.bin", ct_b, SerType::BINARY))
         throw std::runtime_error("Failed to load ciphertext b");
 
-    // ---- Reserve slots 17..24 (compiler's VirtualZero range) and load keys ----
-    niobium::compiler().reserve_addresses(25);
+    // ---- Load keys ----
     {
         std::ifstream mkStream(keyDir + "/mk.bin", std::ios::in | std::ios::binary);
         if (mkStream.is_open()) {
@@ -83,6 +73,9 @@ int main(int argc, char* argv[]) {
     }
 
     // ---- Capture crypto context and tag polys for simulator ----
+    // Address allocation is lazy (matches compiler's compact_address):
+    // poly IDs exist from deserialization but only get FHETCH addresses
+    // when they're first tagged or referenced in the trace.
     niobium::compiler().capture_crypto_context(cc);
     niobium::compiler().tag_input("ct_a", ct_a);
     niobium::compiler().tag_input("ct_b", ct_b);

--- a/examples/simple_ops/server.cpp
+++ b/examples/simple_ops/server.cpp
@@ -54,18 +54,13 @@ int main(int argc, char* argv[]) {
     if (!Serial::DeserializeFromFile(keyDir + "/cc.bin", cc, SerType::BINARY))
         throw std::runtime_error("Failed to load crypto context");
 
-    // Compiler-matching FHETCH layout: inputs in 1..24, evalmult keys at 25+.
-    niobium::compiler().reserve_addresses(1);
-
-    // ---- Load ciphertexts (consume addresses 1..16) ----
+    // ---- Load ciphertexts and keys (addresses assigned later at tag time) ----
     Ciphertext<DCRTPoly> ct_a, ct_b;
     if (!Serial::DeserializeFromFile(keyDir + "/ct_a.bin", ct_a, SerType::BINARY))
         throw std::runtime_error("Failed to load ciphertext a");
     if (!Serial::DeserializeFromFile(keyDir + "/ct_b.bin", ct_b, SerType::BINARY))
         throw std::runtime_error("Failed to load ciphertext b");
 
-    // ---- Reserve and load eval mult + automorphism keys at address 25+ ----
-    niobium::compiler().reserve_addresses(25);
     bool has_mult_key = false;
     {
         std::ifstream mkStream(keyDir + "/mk.bin", std::ios::binary);

--- a/src/auto_facade.cpp
+++ b/src/auto_facade.cpp
@@ -186,7 +186,10 @@ static void capture_ciphertext_polys(niobium::Compiler& compiler,
     for (const auto& dcrt : elements) {
         for (const auto& poly : dcrt.GetAllElements()) {
             uintptr_t poly_id = poly.GetId();
-            uint64_t fhetch_addr = niobium::detail::lookup_fhetch_address(poly_id);
+            // Pin + allocate a FHETCH address lazily (matches the
+            // compiler's compact_address at tag time).
+            niobium::detail::pin_openfhe_id(poly_id);
+            uint64_t fhetch_addr = niobium::detail::ensure_fhetch_address(poly_id);
             if (fhetch_addr == static_cast<uint64_t>(-1)) continue;
 
             addr_ids.push_back(fhetch_addr);
@@ -316,7 +319,11 @@ static size_t capture_dcrt_polys(Compiler& compiler,
             // through any reassignments (inputs/keys/precompute must survive
             // the address-recycling layer).
             detail::pin_openfhe_id(poly_id);
-            uint64_t fhetch_addr = detail::lookup_fhetch_address(poly_id);
+            // Allocate a FHETCH address if the poly didn't already get one.
+            // Setup-time probes no longer allocate addresses — tag_* is the
+            // intended mapping point, giving inputs/keys/precompute low
+            // compact ids before the trace starts consuming the space.
+            uint64_t fhetch_addr = detail::ensure_fhetch_address(poly_id);
             if (fhetch_addr == static_cast<uint64_t>(-1)) continue;
 
             if (poly.GetFormat() != Format::EVALUATION)

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -152,6 +152,17 @@ void Compiler::init(int& argc, char** argv) {
 
 bool Compiler::start() {
     if (impl_->running) return false;
+
+    // Auto-register any CC-derived precomputed data (e.g. CKKS bootstrap
+    // precompute) BEFORE recording begins — mirrors the compiler's
+    // Compiler::start() which calls pin_address + compact_address on every
+    // bootstrap precompute poly so they get compact ids in a contiguous
+    // block right after eval keys, ahead of any trace-intermediate polys.
+    if (impl_->auto_capture_at_stop) {
+        impl_->auto_capture_at_stop();
+        impl_->auto_capture_at_stop = nullptr;  // don't run twice
+    }
+
     impl_->running = true;
     impl_->stopped = false;
     impl_->trace_writer.start_recording();

--- a/src/compiler_internal.h
+++ b/src/compiler_internal.h
@@ -30,6 +30,13 @@ const std::unordered_map<uint64_t, uint64_t>& get_data_parent_map();
 /// whose values must remain accessible for the whole replay.
 void pin_openfhe_id(uintptr_t poly_id);
 
+/// Allocate a FHETCH address for this OpenFHE poly id if one hasn't been
+/// assigned yet. Matches the compiler's compact_address() semantics:
+/// lazy allocation at the point of first use. Used by tag_* paths before
+/// start() so that inputs / keys / bootstrap precompute get low, stable
+/// compact ids before trace-referenced polys start consuming the space.
+uint64_t ensure_fhetch_address(uintptr_t openfhe_poly_id);
+
 /// Diagnostic counters.
 uintptr_t niobium_precompute_probe_count();
 uintptr_t niobium_precompute_probe_already_mapped_count();

--- a/src/probes.cpp
+++ b/src/probes.cpp
@@ -155,22 +155,27 @@ void openfhe_cprobe_annotate(const char* annotation) {
 // Polynomial identity and address tracking
 // ============================================================================
 
+// Mirrors the compiler's Generator::allocate(): on every Poly construction
+// we track the refcount (used by reassign-id recycling) but DO NOT assign a
+// FHETCH address here. Addresses are allocated lazily — for inputs / keys /
+// bootstrap precompute via explicit tag_* calls before start(), for trace-
+// referenced polys via the arithmetic/copy probes during recording. This
+// prevents setup-time intermediates (thousands of them allocated during
+// EvalBootstrapSetup) from eating up the low-address range.
 void openfhe_cprobe_id(uintptr_t poly_id) {
     std::lock_guard<std::mutex> lock(g_probe_mutex);
-    map_address(poly_id);
-    // A freshly-constructed poly has exactly one reference (itself).
     g_refcount.emplace(poly_id, 1);
 }
 
 uintptr_t* openfhe_cprobe_address(uintptr_t poly_id) {
     std::lock_guard<std::mutex> lock(g_probe_mutex);
-    map_address(poly_id);
+    if (niobium::compiler().running_p()) map_address(poly_id);
     return nullptr;
 }
 
 uintptr_t* openfhe_cprobe_result(uintptr_t poly_id) {
     std::lock_guard<std::mutex> lock(g_probe_mutex);
-    map_address(poly_id);
+    if (niobium::compiler().running_p()) map_address(poly_id);
     return nullptr;
 }
 
@@ -182,24 +187,32 @@ uintptr_t* openfhe_cprobe_cache() {
 // Polynomial initialization
 // ============================================================================
 
+// Random-distribution probes: just pin the id (non-reproducible data).
+// Address is assigned lazily when the poly is actually referenced in the
+// trace or tagged. Matches the compiler's Generator::discrete_gaussian
+// etc. which bail with !running_p() except for pinning bookkeeping.
 void openfhe_cprobe_discrete_gaussian(uintptr_t poly_id, int /*format*/) {
     std::lock_guard<std::mutex> lock(g_probe_mutex);
-    map_address(poly_id);
+    g_pinned_openfhe_ids.insert(poly_id);
+    if (niobium::compiler().running_p()) map_address(poly_id);
 }
 
 void openfhe_cprobe_discrete_uniform(uintptr_t poly_id, int /*format*/) {
     std::lock_guard<std::mutex> lock(g_probe_mutex);
-    map_address(poly_id);
+    g_pinned_openfhe_ids.insert(poly_id);
+    if (niobium::compiler().running_p()) map_address(poly_id);
 }
 
 void openfhe_cprobe_binary_uniform(uintptr_t poly_id, int /*format*/) {
     std::lock_guard<std::mutex> lock(g_probe_mutex);
-    map_address(poly_id);
+    g_pinned_openfhe_ids.insert(poly_id);
+    if (niobium::compiler().running_p()) map_address(poly_id);
 }
 
 void openfhe_cprobe_ternary_uniform(uintptr_t poly_id, int /*format*/) {
     std::lock_guard<std::mutex> lock(g_probe_mutex);
-    map_address(poly_id);
+    g_pinned_openfhe_ids.insert(poly_id);
+    if (niobium::compiler().running_p()) map_address(poly_id);
 }
 
 // Number of times precompute probe fired vs. how many of those id's are
@@ -212,27 +225,28 @@ void openfhe_cprobe_precompute(uintptr_t poly_id, int /*format*/) {
     ++g_precompute_probe_count;
     if (g_address_map.find(poly_id) != g_address_map.end())
         ++g_precompute_probe_already_mapped;
-    // Precomputes hold irreproducible data (bootstrap DFT plaintexts,
-    // random-distribution polys, etc.); pin the id so refcount-based
-    // recycling never touches its compact FHETCH address.
+    // Pin the id; address assignment is deferred to tag_bootstrap_precompute
+    // (or lazy trace-time allocation if the poly ends up in an op).
     g_pinned_openfhe_ids.insert(poly_id);
-    map_address(poly_id);
 }
 
 void openfhe_cprobe_zero(uintptr_t poly_id, int /*format*/, uint64_t modulus) {
     std::lock_guard<std::mutex> lock(g_probe_mutex);
-    uintptr_t a = map_address(poly_id);
+    // Skip outside recording (matches compiler's Generator::zero which
+    // bails on !running_p()). During EvalBootstrapSetup this probe fires
+    // thousands of times for intermediate DCRTPoly towers — allocating
+    // addresses for them eats up the compact id space.
+    if (!niobium::compiler().running_p()) return;
 
-    // Emit muli by 0 unconditionally to initialize the address to zero.
-    // emit_preamble works even before start().
+    uintptr_t a = map_address(poly_id);
     std::string mi = (modulus != 0) ? midx(modulus) : "m=0";
-    niobium::detail::trace_writer().emit_preamble(
+    niobium::detail::trace_writer().emit(
         "sr_mulps " + addr(a) + ", " + addr(a) + ", 0, " + mi);
 }
 
 void openfhe_cprobe_max(uintptr_t poly_id, int /*format*/, uint64_t /*modulus*/) {
     std::lock_guard<std::mutex> lock(g_probe_mutex);
-    map_address(poly_id);
+    if (niobium::compiler().running_p()) map_address(poly_id);
 }
 
 // ============================================================================
@@ -241,17 +255,17 @@ void openfhe_cprobe_max(uintptr_t poly_id, int /*format*/, uint64_t /*modulus*/)
 
 void openfhe_cprobe_input(uintptr_t poly_id, int /*format*/) {
     std::lock_guard<std::mutex> lock(g_probe_mutex);
-    map_address(poly_id);
+    if (niobium::compiler().running_p()) map_address(poly_id);
 }
 
 void openfhe_cprobe_output(uintptr_t poly_id, int /*format*/) {
     std::lock_guard<std::mutex> lock(g_probe_mutex);
-    map_address(poly_id);
+    if (niobium::compiler().running_p()) map_address(poly_id);
 }
 
 void openfhe_cprobe_key(uintptr_t poly_id, int /*format*/) {
     std::lock_guard<std::mutex> lock(g_probe_mutex);
-    map_address(poly_id);
+    if (niobium::compiler().running_p()) map_address(poly_id);
 }
 
 // ============================================================================
@@ -261,16 +275,15 @@ void openfhe_cprobe_key(uintptr_t poly_id, int /*format*/) {
 void openfhe_cprobe_copy(uintptr_t dst_id, uintptr_t src_id) {
     std::lock_guard<std::mutex> lock(g_probe_mutex);
     if (g_serialization_thread) return;
+    // Matches the compiler's Generator::copy(): bail entirely if not
+    // recording. Setup-time copies shouldn't reach the trace or
+    // allocate addresses — they just consume compact id space.
+    if (!niobium::compiler().running_p()) return;
+
     uintptr_t src_addr = map_address(src_id);
     uintptr_t dst_addr = map_address(dst_id);
     g_data_parent[dst_addr] = src_addr;
 
-    // Only emit a copy instruction while recording — matches the
-    // compiler's Generator::copy() which bails out when !running_p().
-    // Copies that happen during setup don't belong in the trace;
-    // emitting them there would reference polys that die before
-    // replay and whose FHETCH addresses may be recycled.
-    if (!niobium::compiler().running_p()) return;
     niobium::detail::trace_writer().emit(
         "sr_addps " + addr(dst_addr) + ", " + addr(src_addr) + ", 0, m=0");
 }
@@ -278,9 +291,12 @@ void openfhe_cprobe_copy(uintptr_t dst_id, uintptr_t src_id) {
 void openfhe_cprobe_move(uintptr_t dst_id, uintptr_t src_id) {
     std::lock_guard<std::mutex> lock(g_probe_mutex);
     if (g_serialization_thread) return;
+    // Matches the compiler's Generator::move(): bail if not recording.
+    // Setup-time moves (very common from std::move() of intermediate
+    // polys in OpenFHE's EvalBootstrapSetup) must not allocate addresses.
+    if (!niobium::compiler().running_p()) return;
     uintptr_t src_addr = map_address(src_id);
     g_address_map[dst_id] = src_addr;
-    // dst_id now points to the same FHETCH address as src_id
 }
 
 // Copy-assignment: `poly_dst = poly_src` causes OpenFHE to set
@@ -502,6 +518,11 @@ uint64_t lookup_fhetch_address(uintptr_t openfhe_poly_id) {
     auto it = g_address_map.find(openfhe_poly_id);
     if (it != g_address_map.end()) return it->second;
     return static_cast<uint64_t>(-1);
+}
+
+uint64_t ensure_fhetch_address(uintptr_t openfhe_poly_id) {
+    std::lock_guard<std::mutex> lock(g_probe_mutex);
+    return map_address(openfhe_poly_id);
 }
 
 const std::unordered_map<uint64_t, uint64_t>& get_data_parent_map() {


### PR DESCRIPTION
## Summary

Switch to lazy address allocation, matching the compiler's \`compact_address\` model: addresses get assigned at **point-of-first-use** rather than eagerly at every Poly construction. Previously, every setup-time probe (zero, copy, move, discrete_*, id, precompute) called \`map_address\` unconditionally — each firing consumed one compact id. EvalBootstrapSetup's ~220K intermediate polys thus pushed bootstrap precompute plaintexts to the top of the address space.

Now:
- constructor / distribution / copy / move probes only allocate addresses while recording;
- \`tag_input\` / \`tag_keys\` / \`tag_bootstrap_precompute\` explicitly allocate at tag time via a new \`ensure_fhetch_address\` helper.

\`Compiler::start()\` now runs the auto-capture hook **before** recording begins (it used to run at \`stop()\`), so the bootstrap-precompute plaintexts get their compact ids assigned right after the eval keys — exactly what the compiler's \`Compiler::start()\` does when it calls \`pin_address + compact_address\` on every bp poly.

## Before / after — bootstrap id layout vs compiler -O0

| Range | Before | After | Compiler -O0 |
|---|---|---|---|
| inp | \`9768..9771\` | **\`0..3\`** | \`1..4\` |
| mk | \`0..263\` | **\`4..267\`** | \`5..268\` |
| rk | \`264..9767\` | **\`268..9771\`** | \`269..9772\` |
| bp | \`233505..236708\` (18× high) | **\`9772..12975\`** | \`9773..12976\` |

Same width, same order as compiler -O0. The remaining +1 offset is because the compiler reserves id 0 as a sentinel; we don't.

## Changes

### probes (\`src/probes.cpp\`)
Every constructor / distribution / copy / move / result / address / input / output / key / max / zero / precompute probe now either:
- skips entirely outside recording (the compiler's behavior), or
- allocates an address only while \`running_p()\`.

New \`detail::ensure_fhetch_address(poly_id)\` — allocate-if-missing, used by tag paths.

### compiler (\`src/compiler.cpp\`)
\`Compiler::start()\` invokes the auto_capture_at_stop hook **before** \`start_recording()\`, then clears the hook so \`stop()\` doesn't re-fire it. Mirrors the compiler's \`Compiler::start()\`, which pre-registers bootstrap precompute addresses before recording begins.

### examples
Removed every \`reserve_addresses(...)\` call from \`mult/server.cpp\`, \`simple_ops/server.cpp\`, \`bootstrap/server.cpp\`. With lazy allocation, load order no longer influences the layout — only the order of \`tag_*\` calls does, and they're already in the right order.

## Regression tests

| Test | Status |
|---|---|
| \`make test-simple-ops-release\` | 13/13 PASS |
| \`make test-mult-release\` | PASS (7 × 13 = 91) |
| \`make test-bootstrap-release\` | replay 849261 ops, decrypt still fails on approximation-error (separate numerical-precision issue) |

## Test plan
- [ ] \`make test-simple-ops-release\` — 13/13 PASS
- [ ] \`make test-mult-release\` — PASS
- [ ] bootstrap .ids files byte-compared to compiler-O0 — shapes match (off by +1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)