### PR TITLE
Reserve FHETCH address 0 as a sentinel (compiler-O0 parity)

### DIFF
--- a/src/probes.cpp
+++ b/src/probes.cpp
@@ -23,7 +23,9 @@
 
 static std::mutex g_probe_mutex;
 static std::unordered_map<uintptr_t, uintptr_t> g_address_map;
-static uintptr_t g_next_fhetch_addr = 0;
+// Address 0 is reserved as a sentinel (matches the compiler's layout,
+// which leaves id 0 unused); first allocated FHETCH address is 1.
+static uintptr_t g_next_fhetch_addr = 1;
 
 // ----- Compact address recycling (mirrors niobium-compiler Generator) -----
 // Polys that OpenFHE destroys return their compact address to this pool;


### PR DESCRIPTION
## Summary

Start \`g_next_fhetch_addr\` at \`1\` instead of \`0\`. Matches the compiler's layout, which leaves id 0 unused as a sentinel. Closes the +1 gap left by #23.

## Bootstrap id ranges — client vs compiler -O0

| Range | Client | Compiler -O0 | Match |
|---|---|---|---|
| inp | \`1..4\` | \`1..4\` | ✓ |
| mk | \`5..268\` | \`5..268\` | ✓ |
| rk | \`269..9772\` | \`269..9772\` | ✓ |
| bp | \`9773..12976\` | \`9773..12976\` | ✓ |

Every live-in address range now matches byte-for-byte.

## Regression

- simple_ops: 13/13 PASS
- mult: PASS (7 × 13 = 91)

## Test plan
- [ ] \`make test-bootstrap-release\` — .ids ranges line up exactly with compiler-O0
- [ ] \`make test-simple-ops-release\` — 13/13 PASS
- [ ] \`make test-mult-release\` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)