### PR TITLE
Add niobium-fhetch submodule under vendor/

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 [submodule "vendor/json"]
 	path = vendor/json
 	url = https://github.com/nlohmann/json.git
+[submodule "vendor/niobium-fhetch"]
+	path = vendor/niobium-fhetch
+	url = https://github.com/NiobiumInc/niobium-fhetch.git


### PR DESCRIPTION
## Summary
- Vendors [NiobiumInc/niobium-fhetch](https://github.com/NiobiumInc/niobium-fhetch) at `vendor/niobium-fhetch`, alongside the existing `vendor/openfhe` and `vendor/json` submodules.
- Registers the submodule in `.gitmodules`; pinned to commit `0bba802` (current HEAD of the niobium-fhetch default branch at the time of this PR).

## Test plan
- [ ] `git submodule update --init --recursive` from a fresh clone checks out `vendor/niobium-fhetch` at the pinned commit.
- [ ] Existing builds still succeed (no source change here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)