### PR TITLE
Use SSH URL for `vendor/niobium-fhetch` submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/niobium-fhetch"]
 	path = vendor/niobium-fhetch
-	url = https://github.com/NiobiumInc/niobium-fhetch.git
+	url = git@github.com:NiobiumInc/niobium-fhetch.git


### PR DESCRIPTION
Align with the SSH convention used by every other submodule in the `niobium-compiler` / `niobium-client` repository chain.