### PR TITLE
Add automated PR code review with Claude Code Action

### DIFF
--- a/.github/instructions/CODE_REVIEW_GUIDE.md
+++ b/.github/instructions/CODE_REVIEW_GUIDE.md
@@ -1,0 +1,123 @@
+# Code Review Guide — Niobium Client
+
+This guide defines how automated and manual PR reviews should be conducted for the `niobium-client` repository. Reviews must be actionable, concise, and focused on correctness and security.
+
+> **Scope reminder**: This is an FHE *client* — not a compiler. It generates CKKS crypto contexts and keys, encrypts plaintexts, and serializes ciphertexts/keys to disk for consumption by the Niobium hardware accelerator. All code here is FHE application code, so circuit correctness and parameter security apply everywhere.
+
+> **Automated review scope**: Automated reviews perform static file analysis only (Read, Write, Edit tools). Build validation (`make`, `make examples`) and runtime correctness require manual review or dedicated CI workflows.
+
+---
+
+## Project Context
+
+- **What it is**: FHE client-side application code that generates CKKS crypto contexts, key pairs, and ciphertexts to be consumed by the Niobium hardware accelerator (via `niobium-fhetch`).
+- **Stack**: C++17, openFHE, CMake.
+- **Key subsystems**: Examples (`examples/`), FHETCH vendor library (`vendor/niobium-fhetch`).
+
+---
+
+## 1. Required Review Output
+
+Every review must produce these sections in order:
+
+1. **Summary** (2–4 lines): what changed and why, as inferred from the diff.
+2. **Blockers** (must-fix): incorrect crypto parameters, secret key exposure, serialization bugs, broken build.
+3. **Risks / Watch-outs**: areas likely to regress silently — insecure parameter choices, incorrect key load order, ciphertext level exhaustion.
+4. **Non-blocking suggestions**: code duplication between examples, unnecessary I/O, clarity.
+5. **Questions for the author**: missing context, unclear parameter choices, expected behavior.
+
+Label every issue: **Blocker / High / Medium / Low**.
+
+---
+
+## 2. PR Risk Classification
+
+### Blocker — must not merge
+- `SetSecurityLevel` set to `HEStd_NotSet` in non-example/non-test code without explicit justification
+- Secret key (`secretKey` / `sk.bin`) serialized or exposed in an unintended path
+- CKKS parameters that produce an insecure or broken scheme (ring dimension < 2048 without explicit security justification, modulus sizes that violate standard bounds)
+- Serialization format change that breaks compatibility with existing key/ciphertext files without a migration path
+- Build broken in Debug or Release mode
+
+### High Risk — deep review required
+- Changes to `vendor/niobium-fhetch` (submodule bump or direct edits)
+- Changes to `CMakeLists.txt` or `Makefile` (build system, OpenFHE dependency, flags)
+- New or changed CKKS parameter sets (`CCParams` configuration)
+- Changes to key generation flow (`KeyGen`, `EvalMultKeyGen`, `EvalRotateKeyGen`)
+- Changes to serialization/deserialization of any crypto material (contexts, keys, ciphertexts)
+
+### Medium Risk — targeted review
+- New examples or changes to existing examples
+- Changes to plaintext packing logic or slot layout
+
+### Low Risk — light review
+- Docs, comments, README updates
+- Small isolated refactors with no behavior change
+
+---
+
+## 3. Core Correctness Checklist
+
+### 3.1 CKKS Parameter Security
+This is the highest-priority check for any change touching `CCParams` configuration.
+
+- **Security level**: `HEStd_NotSet` disables parameter validation — only acceptable in explicitly marked development/test code. Flag any use in production paths.
+- **Ring dimension**: Values below 2048 are insecure for any real workload. Flag ring dims < 4096 unless the justification is clear.
+- **Modulus sizes**: `ScalingModSize` and `FirstModSize` affect noise and security. Changes must not weaken the security margin versus standard CKKS recommendations.
+- **Multiplicative depth**: Must match the actual circuit depth in the corresponding server code. Mismatches cause decryption failures that are silent at encryption time.
+- **Scaling technique**: Changes to `ScalingTechnique` (e.g., `FIXEDMANUAL` → `FLEXIBLEAUTO`) affect noise behavior across the whole circuit — flag any change.
+
+### 3.2 Key Management
+- **Secret key serialization**: `secretKey` / `sk.bin` must only be written when explicitly required (e.g., for the decrypt binary). Flag any unintended serialization to shared or public directories.
+- **Key load order**: Public key must be available before encrypting; eval keys (mult, rotation) must be generated before the server attempts to use them. Mismatches cause silent failures at the server.
+- **Rotation key indices**: `EvalRotateKeyGen` indices must match the rotation offsets actually used in the server/compiler. Missing indices produce incorrect results without error.
+- **Key file paths**: Hardcoded paths must use `std::filesystem` safely. No path traversal from user input.
+
+### 3.3 Ciphertext Correctness
+- **Slot packing**: The number of slots packed into a ciphertext must match what the server expects. Review the comment or usage context to confirm alignment.
+- **Level budget**: The multiplicative depth set in `CCParams` is the level budget. If the server circuit consumes more levels than the client allocated, decryption produces garbage.
+- **Plaintext type**: `MakeCKKSPackedPlaintext` is correct for CKKS. Flag use of non-CKKS plaintext constructors.
+- **Ciphertext file names**: File names (e.g., `ct_a.bin`, `ct_b.bin`) must match what `fhetch_driver` or server code expects. Mismatches cause silent load failures.
+
+### 3.4 Code and Data Structure Reuse
+- Does the new example duplicate boilerplate (param setup, key gen, serialization) that could be shared with an existing example? Flag and suggest a shared helper if the duplication is significant.
+- Are two examples using structurally identical `CCParams` blocks? Confirm the parameters are intentionally different before accepting.
+- Does the new code reimplement a utility already available in openFHE or the C++17 STL?
+
+### 3.5 C++17 Memory Safety
+- No raw owning pointers — use `std::unique_ptr` or `std::shared_ptr`.
+- No manual `new`/`delete` unless wrapping a C API.
+- RAII for all file handles (`std::ofstream`/`std::ifstream` — close explicitly or use scope).
+- No unguarded array or vector accesses — validate indices before use.
+- No `strcpy`/`sprintf` without bounds — use `std::string` or bounded alternatives.
+
+### 3.6 File I/O and Paths
+- Does the change write files to a directory that may not exist? `std::filesystem::create_directories` must be called before any write.
+- Are file open results checked? An unchecked `std::ofstream` that fails silently produces a corrupted or missing key file.
+- Is a binary stream opened without `std::ios::binary`? OpenFHE serialization requires binary mode — text mode causes corruption on Windows and subtle bugs elsewhere.
+- Are file paths constructed from user input? Validate or sanitize to prevent path traversal.
+
+### 3.7 Build System
+- Does the change require OpenFHE to be rebuilt? Flag this explicitly in the review.
+- Are Debug and Release builds both correct? Some bugs only appear in Release (optimizations, `NDEBUG`).
+- Are new source files added to the correct `CMakeLists.txt`?
+- Are new dependencies introduced? They must be documented and available in CI.
+- Does a submodule bump to `vendor/niobium-fhetch` change the OpenFHE version transitively? Flag if so.
+
+### 3.8 FHE Circuit Correctness
+> Unlike the compiler repo, this section applies to **all code** in this repository.
+
+- **Relinearization**: Every ciphertext multiplication must be followed by relinearization before further multiplications (`EvalMultNoRelin` requires explicit relinearization; `EvalMult` with eval keys handles it automatically — confirm which is used).
+- **Level consumption**: Operations that consume levels (multiplication, modswitch, relinearization) must be tracked. The client's `MultiplicativeDepth` must account for all levels consumed by the server circuit.
+- **Noise budget**: Does the parameter set leave sufficient noise margin for the circuit depth? Deeper circuits or many rotations require larger ring dimensions.
+- **Rotation key coverage**: All rotation offsets used in the server must have corresponding keys generated by the client.
+
+---
+
+## 4. Comment Style
+
+- **Blocker**: `[Blocker] <problem> — <impact> — <fix>`
+- **High**: `[High] <problem> — <impact> — <suggested fix>`
+- **Medium / Low**: one line is enough unless a fix is non-obvious.
+- Prefer proposing a minimal patch over describing the problem abstractly.
+- Do not flag style issues unless they affect readability or create ambiguity.

--- a/.github/workflows/pr-claude-code-review.yml
+++ b/.github/workflows/pr-claude-code-review.yml
@@ -1,0 +1,189 @@
+name: PR - Claude Code Review
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  full-review:
+    name: PR - Full Code Review
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@claude'))
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v47
+        with:
+          separator: " "
+
+      - name: Claude Full Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 45
+            --allowedTools Edit,Read,Write
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+            You are a code reviewer for PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
+
+            Start by reading the review guide at:
+            .github/instructions/CODE_REVIEW_GUIDE.md
+
+            Then review this PR following the guide.
+            The changed files are: ${{ steps.changed-files.outputs.all_changed_files }}
+
+            For each changed file:
+            1. Read the FULL file content using the Read tool
+            2. Apply the universal checklist from the guide (sections 3)
+
+            Turn limit safety: after reading each file, count the tool calls you have made
+            so far against the --max-turns 45 limit. If the number of files you have not
+            yet read exceeds your estimated remaining turns, stop reading new files and
+            post the review immediately with findings gathered so far, noting which files
+            were skipped due to the turn limit.
+
+            Post a single concise PR comment with only:
+            1. Summary (2–4 lines)
+            2. Blockers (must-fix)
+            3. Risks / Watch-outs
+            4. Non-blocking suggestions
+
+            Rules:
+            - Each issue must be one line: [Severity] file:line — problem — fix
+            - No prose, no elaboration, no closing summary
+            - If a section has no findings, omit it entirely
+            - Label each issue: Blocker / High / Medium / Low
+
+      - name: Usage Summary
+        if: always()
+        run: |
+          EXECUTION_FILE="${{ steps.claude-review.outputs.execution_file }}"
+
+          INPUT=0; OUTPUT=0; TURNS=0
+          if [ -f "$EXECUTION_FILE" ]; then
+            INPUT=$(jq '[.. | objects | select(has("usage")) | .usage.input_tokens // 0] | add // 0' "$EXECUTION_FILE" 2>/dev/null || echo 0)
+            OUTPUT=$(jq '[.. | objects | select(has("usage")) | .usage.output_tokens // 0] | add // 0' "$EXECUTION_FILE" 2>/dev/null || echo 0)
+            TURNS=$(jq '[.. | objects | select(has("type") and (.type == "assistant"))] | length' "$EXECUTION_FILE" 2>/dev/null || echo 0)
+          fi
+          TOTAL=$((INPUT + OUTPUT))
+          COST=$(echo "scale=4; ($INPUT * 3 + $OUTPUT * 15) / 1000000" | bc)
+
+          echo "## PR - Full Code Review — Usage" >> $GITHUB_STEP_SUMMARY
+          echo "| | |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
+          echo "| Model | claude-sonnet-4-6 |" >> $GITHUB_STEP_SUMMARY
+          echo "| Input tokens | $INPUT |" >> $GITHUB_STEP_SUMMARY
+          echo "| Output tokens | $OUTPUT |" >> $GITHUB_STEP_SUMMARY
+          echo "| Total tokens | $TOTAL |" >> $GITHUB_STEP_SUMMARY
+          echo "| Estimated cost | \$$COST USD |" >> $GITHUB_STEP_SUMMARY
+          echo "| Turns used | $TURNS |" >> $GITHUB_STEP_SUMMARY
+
+  partial-review:
+    name: PR - Partial Code Review
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' && github.event.action == 'synchronize'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Get files changed in latest push
+        id: changed-files
+        uses: tj-actions/changed-files@v47
+        with:
+          separator: " "
+          since_last_remote_commit: true
+
+      - name: Claude Partial Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 25
+            --allowedTools Edit,Read,Write
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            You are performing a PARTIAL review of the latest commit to PR #${{ github.event.pull_request.number }}.
+
+            Files changed in this push: ${{ steps.changed-files.outputs.all_changed_files }}
+
+            Start by reading the review guide at:
+            .github/instructions/CODE_REVIEW_GUIDE.md
+
+            For each changed file:
+            1. Read the relevant sections using the Read tool
+            2. Apply the full checklist from the guide (sections 3), but report ONLY findings
+               rated Blocker or High — skip Medium and Low entirely
+
+            Turn limit safety: after reading each file, count the tool calls you have made
+            so far against the --max-turns 25 limit. If the number of files you have not
+            yet read exceeds your estimated remaining turns, stop reading new files and
+            post the review immediately with findings gathered so far, noting which files
+            were skipped due to the turn limit.
+
+            Post a single concise PR comment with only:
+            1. What changed in this commit (1 line)
+            2. Blockers — if any
+            3. High risks — if any
+
+            Rules:
+            - Each issue must be one line: [Severity] file:line — problem — fix
+            - No prose, no elaboration, no closing summary
+            - If no blockers or high risks found, post only: "✅ No blockers or high risks in this commit."
+
+      - name: Usage Summary
+        if: always()
+        run: |
+          EXECUTION_FILE="${{ steps.claude-review.outputs.execution_file }}"
+
+          INPUT=0; OUTPUT=0; TURNS=0
+          if [ -f "$EXECUTION_FILE" ]; then
+            INPUT=$(jq '[.. | objects | select(has("usage")) | .usage.input_tokens // 0] | add // 0' "$EXECUTION_FILE" 2>/dev/null || echo 0)
+            OUTPUT=$(jq '[.. | objects | select(has("usage")) | .usage.output_tokens // 0] | add // 0' "$EXECUTION_FILE" 2>/dev/null || echo 0)
+            TURNS=$(jq '[.. | objects | select(has("type") and (.type == "assistant"))] | length' "$EXECUTION_FILE" 2>/dev/null || echo 0)
+          fi
+          TOTAL=$((INPUT + OUTPUT))
+          COST=$(echo "scale=4; ($INPUT * 3 + $OUTPUT * 15) / 1000000" | bc)
+
+          echo "## PR - Partial Code Review — Usage" >> $GITHUB_STEP_SUMMARY
+          echo "| | |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
+          echo "| Model | claude-sonnet-4-6 |" >> $GITHUB_STEP_SUMMARY
+          echo "| Input tokens | $INPUT |" >> $GITHUB_STEP_SUMMARY
+          echo "| Output tokens | $OUTPUT |" >> $GITHUB_STEP_SUMMARY
+          echo "| Total tokens | $TOTAL |" >> $GITHUB_STEP_SUMMARY
+          echo "| Estimated cost | \$$COST USD |" >> $GITHUB_STEP_SUMMARY
+          echo "| Turns used | $TURNS |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
 ## Summary

  - Add `.github/workflows/pr-claude-code-review.yml` with two jobs:
    **full-review** (on PR open/reopen, 45 turns) and **partial-review**
    (on push, 25 turns, Blocker/High only)
  - Add `.github/instructions/CODE_REVIEW_GUIDE.md` tailored to this
    repository's stack (C++17, openFHE, CKKS client code)

  ## Details

  The review guide covers CKKS parameter security, key management,
  ciphertext correctness, C++17 memory safety, file I/O, and build system
  checks. Unlike the compiler repo guide, FHE circuit correctness applies
  to all code here (not only tests/examples).

  Both prompts include a turn-limit safety instruction: if Claude estimates
  the remaining turn budget is insufficient to finish all pending files, it
  posts the review with findings gathered so far and notes which files were
  skipped.