### PR TITLE
chore(build): add -Wunused-but-set-variable; bump fhetch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,9 +21,12 @@ endif()
 # Compiler flags
 # -Wno-ignored-qualifiers and -Wno-missing-field-initializers are required for
 # OpenFHE headers which trigger these warnings under -Werror.
-set(CMAKE_CXX_FLAGS_DEBUG   "-Og -g -Wall -Wextra -Wno-unknown-pragmas -Wno-unused-parameter -Wno-ignored-qualifiers -Wno-missing-field-initializers -Werror"
+# -Wunused-but-set-variable is in clang's -Wall but not in GCC's, so add it
+# explicitly so both toolchains catch the same class of dead-code bugs locally
+# before CI (macOS runners use clang; Linux dev machines often use GCC).
+set(CMAKE_CXX_FLAGS_DEBUG   "-Og -g -Wall -Wextra -Wunused-but-set-variable -Wno-unknown-pragmas -Wno-unused-parameter -Wno-ignored-qualifiers -Wno-missing-field-initializers -Werror"
     CACHE STRING "C++ flags for Debug builds" FORCE)
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -Wextra -Wno-unknown-pragmas -Wno-unused-parameter -Wno-ignored-qualifiers -Wno-missing-field-initializers -Werror"
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -Wextra -Wunused-but-set-variable -Wno-unknown-pragmas -Wno-unused-parameter -Wno-ignored-qualifiers -Wno-missing-field-initializers -Werror"
     CACHE STRING "C++ flags for Release builds" FORCE)
 
 option(BUILD_SHARED_LIBS "Build shared libraries instead of static ones" ON)


### PR DESCRIPTION
- Mirror the -Wunused-but-set-variable addition from niobium-fhetch so the client build catches the same dead-store class that slipped past GCC's -Wall and tripped macOS clang CI.
- Bump vendor/niobium-fhetch to pick up the companion flag change plus the skipped_keys drop that caused the original CI break.