### PR TITLE
Dispatch compiler update trigger on PR merge

### DIFF
--- a/.github/workflows/dispatch-to-compiler-on-merge.yml
+++ b/.github/workflows/dispatch-to-compiler-on-merge.yml
@@ -1,0 +1,39 @@
+name: Dispatch to niobium-compiler on merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Dispatch client_merged to niobium-compiler
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          jq -n \
+            --arg sha "$MERGE_SHA" \
+            --argjson pr_number "$PR_NUMBER" \
+            --arg pr_title "$PR_TITLE" \
+            '{event_type: "client_merged", client_payload: {sha: $sha, pr_number: $pr_number, pr_title: $pr_title}}' \
+          | gh api --method POST \
+              repos/${{ github.repository_owner }}/niobium-compiler/dispatches \
+              --input -


### PR DESCRIPTION
## Summary

  Adds a workflow that notifies `niobium-compiler` whenever a PR is
  merged into `main`.

  - On merge, sends a `repository_dispatch` event (`client_merged`) to
    `niobium-compiler` with the merge commit SHA and PR metadata
  - niobium-compiler uses this event to detect the new commit and
    automatically open a PR bumping its `vendor/niobium-client` submodule