### PR TITLE
 Fix and finalize auto PR workflow from niobium-fhetch

### DIFF
--- a/.github/workflows/auto-pr-from-fhetch.yml
+++ b/.github/workflows/auto-pr-from-fhetch.yml
@@ -58,6 +58,8 @@ jobs:
         run: |
           [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || { echo "Invalid PR_NUMBER: $PR_NUMBER"; exit 1; }
 
+          git fetch origin main --depth=1
+
           BRANCH="auto/fhetch-pr-${PR_NUMBER}"
 
           if git ls-remote --exit-code --heads origin "$BRANCH" > /dev/null 2>&1; then

--- a/.github/workflows/auto-pr-from-fhetch.yml
+++ b/.github/workflows/auto-pr-from-fhetch.yml
@@ -3,6 +3,21 @@ name: Auto PR — bump niobium-fhetch submodule
 on:
   repository_dispatch:
     types: [fhetch_pr]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'niobium-fhetch PR number'
+        required: true
+      sha:
+        description: 'Head commit SHA of the fhetch PR'
+        required: true
+      branch:
+        description: 'Head branch of the fhetch PR'
+        required: true
+      pr_title:
+        description: 'Title of the fhetch PR'
+        required: true
+        default: 'Test dispatch'
 
 permissions:
   contents: write
@@ -36,9 +51,9 @@ jobs:
       - name: Create or update branch
         id: update
         env:
-          PR_NUMBER: ${{ github.event.client_payload.pr_number }}
-          FHETCH_SHA: ${{ github.event.client_payload.sha }}
-          FHETCH_BRANCH: ${{ github.event.client_payload.branch }}
+          PR_NUMBER: ${{ github.event.client_payload.pr_number || github.event.inputs.pr_number }}
+          FHETCH_SHA: ${{ github.event.client_payload.sha || github.event.inputs.sha }}
+          FHETCH_BRANCH: ${{ github.event.client_payload.branch || github.event.inputs.branch }}
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || { echo "Invalid PR_NUMBER: $PR_NUMBER"; exit 1; }
@@ -72,8 +87,8 @@ jobs:
         if: steps.update.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ github.event.client_payload.pr_number }}
-          PR_TITLE: ${{ github.event.client_payload.pr_title }}
+          PR_NUMBER: ${{ github.event.client_payload.pr_number || github.event.inputs.pr_number }}
+          PR_TITLE: ${{ github.event.client_payload.pr_title || github.event.inputs.pr_title }}
           REPO_OWNER: ${{ github.repository_owner }}
         run: |
           BRANCH="${{ steps.update.outputs.branch }}"

--- a/.github/workflows/auto-pr-from-fhetch.yml
+++ b/.github/workflows/auto-pr-from-fhetch.yml
@@ -51,9 +51,9 @@ jobs:
             git checkout -b "$BRANCH" origin/main
           fi
 
+          git config submodule.vendor/niobium-fhetch.url "https://x-access-token:${APP_TOKEN}@github.com/NiobiumInc/niobium-fhetch.git"
           git submodule update --init vendor/niobium-fhetch
           cd vendor/niobium-fhetch
-          git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/NiobiumInc/niobium-fhetch.git"
           git fetch origin "$FHETCH_BRANCH"
           git checkout "$FHETCH_SHA"
           cd ../..

--- a/.github/workflows/auto-pr-from-fhetch.yml
+++ b/.github/workflows/auto-pr-from-fhetch.yml
@@ -3,21 +3,6 @@ name: Auto PR — bump niobium-fhetch submodule
 on:
   repository_dispatch:
     types: [fhetch_pr]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: 'niobium-fhetch PR number'
-        required: true
-      sha:
-        description: 'Head commit SHA of the fhetch PR'
-        required: true
-      branch:
-        description: 'Head branch of the fhetch PR'
-        required: true
-      pr_title:
-        description: 'Title of the fhetch PR'
-        required: true
-        default: 'Test dispatch'
 
 permissions:
   contents: write
@@ -99,7 +84,7 @@ jobs:
             printf 'Automated submodule bump tracking [niobium-fhetch PR #%s](https://github.com/%s/niobium-fhetch/pull/%s): %s' \
               "$PR_NUMBER" "$REPO_OWNER" "$PR_NUMBER" "$PR_TITLE" > /tmp/pr-body.txt
             gh pr create \
-              --title "chore: bump niobium-fhetch (fhetch PR #${PR_NUMBER})" \
+              --title "Update niobium-fhetch submodule (PR #${PR_NUMBER})" \
               --body-file /tmp/pr-body.txt \
               --base main \
               --head "$BRANCH"


### PR DESCRIPTION
  ## Summary

  Fixes and cleanup after initial testing of the auto PR workflow
  triggered by niobium-fhetch PRs.

  - Fetch `origin/main` explicitly before branch creation to fix
    failure when `fetch-depth: 1` leaves the ref unavailable
  - Scope submodule auth to its own remote URL instead of a
    global git URL rewrite
  - Remove temporary `workflow_dispatch` used for local testing
  - Update auto PR title to "Update niobium-fhetch submodule (PR #N)"

  ## Testing

  - [x] Verified end-to-end: workflow_dispatch test created branch
    `auto/fhetch-pr-18` with submodule pinned to commit `34e4061`
    and opened the PR in niobium-client correctly