### PR TITLE
build: support external niobium-fhetch / openfhe / json injection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,22 @@ set(OPENFHE_LIBRARY_PATH "${OPENFHE_INSTALL_DIR}/lib")
 # Pull in the fhetch library — this defines the niobium_fhetch target and the
 # fhetch_sim CLI. We forward OPENFHE_INSTALL_DIR so its CMakeLists can find
 # OpenFHE headers/libs from the same install tree the client built.
-add_subdirectory(vendor/niobium-fhetch)
+#
+# When this project is built from a parent (e.g. niobium-compiler) that owns
+# its own niobium-fhetch checkout, set NIOBIUM_CLIENT_FHETCH_DIR to that path.
+# The parent's checkout is then used directly; our own vendor/niobium-fhetch
+# submodule does not need to be initialized. JSON_INCLUDE_DIR and
+# OPENFHE_INSTALL_DIR are honored by niobium-fhetch's CMakeLists, so injecting
+# them here covers the full transitive dep set.
+set(NIOBIUM_CLIENT_FHETCH_DIR "" CACHE PATH
+    "External niobium-fhetch source tree to use instead of vendor/niobium-fhetch (empty = use vendored submodule)")
+
+if(NIOBIUM_CLIENT_FHETCH_DIR)
+    add_subdirectory(${NIOBIUM_CLIENT_FHETCH_DIR}
+                     ${CMAKE_BINARY_DIR}/_deps/niobium-fhetch-build)
+else()
+    add_subdirectory(vendor/niobium-fhetch)
+endif()
 
 # ==============================================================================
 # Optional: auto-facade helper library (transparent record/replay for

--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,16 @@ build-openfhe-release: ## Build and install OpenFHE (Release)
 
 ##@ Client Build
 
+# Records build-time deps for scripts/ that run after install (e.g. the
+# transport test scripts on Linux, where there's no rpath fallback). Sourced
+# by scripts/test_transport_mult.sh and scripts/fhetch_server.sh so they
+# point LD_LIBRARY_PATH at whatever OpenFHE the build was actually linked
+# against — the client's own vendored install in standalone builds, or a
+# parent-supplied install when a parent (niobium-compiler) drove the build.
+define write-build-env
+	printf 'OPENFHE_LIB=%s/lib\n' "$(OPENFHE_INSTALL_DIR)" > $(CURDIR)/$(1)/niobium_client.env
+endef
+
 config-client: ## Configure the client + fhetch library + examples (Debug)
 	$(call set-build-config,Debug,dbuild)
 	cmake -S $(CURDIR) -B $(CURDIR)/dbuild \
@@ -177,6 +187,7 @@ config-client: ## Configure the client + fhetch library + examples (Debug)
 		$(CMAKE_JSON_INCLUDE_DIR_FLAG) \
 		-DNIOBIUM_CLIENT_WITH_EXAMPLES=ON \
 		-DCMAKE_INSTALL_PREFIX=$(CLIENT_INSTALL_DIR)
+	@$(call write-build-env,dbuild)
 
 config-client-release: ## Configure the client + fhetch library + examples (Release)
 	$(call set-build-config,Release,build)
@@ -187,6 +198,7 @@ config-client-release: ## Configure the client + fhetch library + examples (Rele
 		$(CMAKE_JSON_INCLUDE_DIR_FLAG) \
 		-DNIOBIUM_CLIENT_WITH_EXAMPLES=ON \
 		-DCMAKE_INSTALL_PREFIX=$(CLIENT_INSTALL_DIR)
+	@$(call write-build-env,build)
 
 ##@ Combined Targets
 

--- a/Makefile
+++ b/Makefile
@@ -56,10 +56,34 @@ endef
 VENDOR_DIR       := $(CURDIR)/vendor
 VENDOR_LIB_DIR   := $(VENDOR_DIR)/lib
 
-FHETCH_DIR           := $(VENDOR_DIR)/niobium-fhetch
-OPENFHE_DIR          := $(FHETCH_DIR)/vendor/openfhe
-OPENFHE_INSTALL_DIR  := $(VENDOR_LIB_DIR)/openfhe
-CLIENT_INSTALL_DIR   := $(VENDOR_LIB_DIR)/niobium-client
+# Paths overridable by a parent build (e.g. niobium-compiler) so the same
+# source tree can be built either standalone (using vendored submodules) or
+# with deps supplied from outside. Use ?= so command-line / env overrides win.
+FHETCH_DIR          ?= $(VENDOR_DIR)/niobium-fhetch
+OPENFHE_DIR         ?= $(FHETCH_DIR)/vendor/openfhe
+OPENFHE_INSTALL_DIR ?= $(VENDOR_LIB_DIR)/openfhe
+JSON_INCLUDE_DIR    ?=
+CLIENT_INSTALL_DIR  := $(VENDOR_LIB_DIR)/niobium-client
+
+# When EXTERNAL_OPENFHE=1, the parent has already built+installed OpenFHE and
+# pointed OPENFHE_INSTALL_DIR at it; we skip our own openfhe config/build
+# steps and the matching submodule sync.
+EXTERNAL_OPENFHE ?= 0
+ifeq ($(EXTERNAL_OPENFHE),1)
+  OPENFHE_CONFIG_DEP_DEBUG   :=
+  OPENFHE_CONFIG_DEP_RELEASE :=
+  OPENFHE_BUILD_DEP_DEBUG    :=
+  OPENFHE_BUILD_DEP_RELEASE  :=
+else
+  OPENFHE_CONFIG_DEP_DEBUG   := config-openfhe
+  OPENFHE_CONFIG_DEP_RELEASE := config-openfhe-release
+  OPENFHE_BUILD_DEP_DEBUG    := build-openfhe
+  OPENFHE_BUILD_DEP_RELEASE  := build-openfhe-release
+endif
+
+# CMake -D flags that are only emitted when the corresponding override is set.
+CMAKE_CLIENT_FHETCH_DIR_FLAG := $(if $(NIOBIUM_CLIENT_FHETCH_DIR),-DNIOBIUM_CLIENT_FHETCH_DIR=$(NIOBIUM_CLIENT_FHETCH_DIR))
+CMAKE_JSON_INCLUDE_DIR_FLAG  := $(if $(JSON_INCLUDE_DIR),-DJSON_INCLUDE_DIR=$(JSON_INCLUDE_DIR))
 
 # OpenMP toggle (OFF by default, override with: make config-openfhe OPENMP=ON)
 OPENMP ?= OFF
@@ -149,6 +173,8 @@ config-client: ## Configure the client + fhetch library + examples (Debug)
 	cmake -S $(CURDIR) -B $(CURDIR)/dbuild \
 		-DCMAKE_BUILD_TYPE=Debug \
 		-DOPENFHE_INSTALL_DIR=$(OPENFHE_INSTALL_DIR) \
+		$(CMAKE_CLIENT_FHETCH_DIR_FLAG) \
+		$(CMAKE_JSON_INCLUDE_DIR_FLAG) \
 		-DNIOBIUM_CLIENT_WITH_EXAMPLES=ON \
 		-DCMAKE_INSTALL_PREFIX=$(CLIENT_INSTALL_DIR)
 
@@ -157,20 +183,22 @@ config-client-release: ## Configure the client + fhetch library + examples (Rele
 	cmake -S $(CURDIR) -B $(CURDIR)/build \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DOPENFHE_INSTALL_DIR=$(OPENFHE_INSTALL_DIR) \
+		$(CMAKE_CLIENT_FHETCH_DIR_FLAG) \
+		$(CMAKE_JSON_INCLUDE_DIR_FLAG) \
 		-DNIOBIUM_CLIENT_WITH_EXAMPLES=ON \
 		-DCMAKE_INSTALL_PREFIX=$(CLIENT_INSTALL_DIR)
 
 ##@ Combined Targets
 
-config: config-openfhe config-client ## Configure everything (Debug)
+config: $(OPENFHE_CONFIG_DEP_DEBUG) config-client ## Configure everything (Debug)
 
-config-release: config-openfhe-release config-client-release ## Configure everything (Release)
+config-release: $(OPENFHE_CONFIG_DEP_RELEASE) config-client-release ## Configure everything (Release)
 
-build: build-openfhe ## Build everything (Debug)
+build: $(OPENFHE_BUILD_DEP_DEBUG) ## Build everything (Debug)
 	$(call set-build-config,Debug,dbuild)
 	cmake --build dbuild -j $(NUM_CPUS) --config Debug
 
-build-release: build-openfhe-release ## Build everything (Release)
+build-release: $(OPENFHE_BUILD_DEP_RELEASE) ## Build everything (Release)
 	$(call set-build-config,Release,build)
 	cmake --build build -j $(NUM_CPUS) --config Release
 
@@ -433,9 +461,9 @@ test-op-release: build-release ## Run a single simple_ops test: make test-op-rel
 # test targets reference $(BUILD_DIR)/… paths relative to its own root).
 # ==============================================================================
 
-test-fhetch-release: build-openfhe-release ## Run the fhetch submodule's test-release (simple_fhetch + fhetch_driver + simple_ops roundtrip)
-	$(MAKE) -C $(FHETCH_DIR) OPENFHE_INSTALL_DIR=$(OPENFHE_INSTALL_DIR) config-fhetch-release
-	$(MAKE) -C $(FHETCH_DIR) OPENFHE_INSTALL_DIR=$(OPENFHE_INSTALL_DIR) test-release
+test-fhetch-release: $(OPENFHE_BUILD_DEP_RELEASE) ## Run the fhetch submodule's test-release (simple_fhetch + fhetch_driver + simple_ops roundtrip)
+	$(MAKE) -C $(FHETCH_DIR) OPENFHE_INSTALL_DIR=$(OPENFHE_INSTALL_DIR) $(if $(JSON_INCLUDE_DIR),JSON_INCLUDE_DIR=$(JSON_INCLUDE_DIR)) EXTERNAL_OPENFHE=$(EXTERNAL_OPENFHE) config-fhetch-release
+	$(MAKE) -C $(FHETCH_DIR) OPENFHE_INSTALL_DIR=$(OPENFHE_INSTALL_DIR) $(if $(JSON_INCLUDE_DIR),JSON_INCLUDE_DIR=$(JSON_INCLUDE_DIR)) EXTERNAL_OPENFHE=$(EXTERNAL_OPENFHE) test-release
 
 # ==============================================================================
 # test-release — everything that currently passes

--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,9 @@ else
 endif
 
 # CMake -D flags that are only emitted when the corresponding override is set.
-CMAKE_CLIENT_FHETCH_DIR_FLAG := $(if $(NIOBIUM_CLIENT_FHETCH_DIR),-DNIOBIUM_CLIENT_FHETCH_DIR=$(NIOBIUM_CLIENT_FHETCH_DIR))
-CMAKE_JSON_INCLUDE_DIR_FLAG  := $(if $(JSON_INCLUDE_DIR),-DJSON_INCLUDE_DIR=$(JSON_INCLUDE_DIR))
+# Quote the path so cmake receives a single argument even if it contains spaces.
+CMAKE_CLIENT_FHETCH_DIR_FLAG := $(if $(NIOBIUM_CLIENT_FHETCH_DIR),-DNIOBIUM_CLIENT_FHETCH_DIR="$(NIOBIUM_CLIENT_FHETCH_DIR)")
+CMAKE_JSON_INCLUDE_DIR_FLAG  := $(if $(JSON_INCLUDE_DIR),-DJSON_INCLUDE_DIR="$(JSON_INCLUDE_DIR)")
 
 # OpenMP toggle (OFF by default, override with: make config-openfhe OPENMP=ON)
 OPENMP ?= OFF
@@ -474,8 +475,8 @@ test-op-release: build-release ## Run a single simple_ops test: make test-op-rel
 # ==============================================================================
 
 test-fhetch-release: $(OPENFHE_BUILD_DEP_RELEASE) ## Run the fhetch submodule's test-release (simple_fhetch + fhetch_driver + simple_ops roundtrip)
-	$(MAKE) -C $(FHETCH_DIR) OPENFHE_INSTALL_DIR=$(OPENFHE_INSTALL_DIR) $(if $(JSON_INCLUDE_DIR),JSON_INCLUDE_DIR=$(JSON_INCLUDE_DIR)) EXTERNAL_OPENFHE=$(EXTERNAL_OPENFHE) config-fhetch-release
-	$(MAKE) -C $(FHETCH_DIR) OPENFHE_INSTALL_DIR=$(OPENFHE_INSTALL_DIR) $(if $(JSON_INCLUDE_DIR),JSON_INCLUDE_DIR=$(JSON_INCLUDE_DIR)) EXTERNAL_OPENFHE=$(EXTERNAL_OPENFHE) test-release
+	$(MAKE) -C $(FHETCH_DIR) OPENFHE_INSTALL_DIR="$(OPENFHE_INSTALL_DIR)" $(if $(JSON_INCLUDE_DIR),JSON_INCLUDE_DIR="$(JSON_INCLUDE_DIR)") EXTERNAL_OPENFHE=$(EXTERNAL_OPENFHE) config-fhetch-release
+	$(MAKE) -C $(FHETCH_DIR) OPENFHE_INSTALL_DIR="$(OPENFHE_INSTALL_DIR)" $(if $(JSON_INCLUDE_DIR),JSON_INCLUDE_DIR="$(JSON_INCLUDE_DIR)") EXTERNAL_OPENFHE=$(EXTERNAL_OPENFHE) test-release
 
 # ==============================================================================
 # test-release — everything that currently passes

--- a/scripts/fhetch_server.sh
+++ b/scripts/fhetch_server.sh
@@ -32,7 +32,13 @@ CLIENT_ROOT="$(cd "$HERE/.." && pwd)"
 
 SERVER_BIN="$CLIENT_ROOT/build/src/fhetch_transport/nbcc_fhetch_replay_server"
 COMPILER_BIN="$NIOBIUM_COMPILER_BUILD/nbcc_fhetch_replay"
-OPENFHE_LIB="$CLIENT_ROOT/vendor/lib/openfhe/lib"
+
+# niobium_client.env (written by `make config-client-release`) records the
+# OpenFHE install dir the build was linked against. See test_transport_mult.sh
+# for the full rationale.
+ENV_FILE="$CLIENT_ROOT/build/niobium_client.env"
+[[ -f "$ENV_FILE" ]] && . "$ENV_FILE"
+: "${OPENFHE_LIB:=$CLIENT_ROOT/vendor/lib/openfhe/lib}"
 NTL_LIB="$NIOBIUM_COMPILER_ROOT/deps/photovoltaic/build/ntl/lib"
 
 for path in "$SERVER_BIN" "$COMPILER_BIN"; do

--- a/scripts/test_transport_mult.sh
+++ b/scripts/test_transport_mult.sh
@@ -28,7 +28,15 @@ CLIENT_ROOT="$(cd "$HERE/.." && pwd)"
 
 BUILD="$CLIENT_ROOT/build"
 TRANSPORT_DIR="$BUILD/src/fhetch_transport"
-OPENFHE_LIB="$CLIENT_ROOT/vendor/lib/openfhe/lib"
+
+# niobium_client.env is written by `make config-client-release` and records
+# the OpenFHE install dir the build was linked against. Source it so we point
+# LD_LIBRARY_PATH at the right place on Linux, where there's no rpath fallback.
+# In compiler-driven builds this picks up the parent's openfhe install; in
+# standalone builds it just records the client's own vendored install.
+ENV_FILE="$BUILD/niobium_client.env"
+[[ -f "$ENV_FILE" ]] && . "$ENV_FILE"
+: "${OPENFHE_LIB:=$CLIENT_ROOT/vendor/lib/openfhe/lib}"
 
 mult_client="$BUILD/examples/mult_client"
 mult_server="$BUILD/examples/mult_server"


### PR DESCRIPTION
Add NIOBIUM_CLIENT_FHETCH_DIR cache var so a parent project (niobium- compiler) can supply its own niobium-fhetch checkout instead of using this repo's vendored submodule. When set, add_subdirectory points at the external path; when empty, behaviour is unchanged.

Mirror the same shape in the Makefile:
- FHETCH_DIR / OPENFHE_DIR / OPENFHE_INSTALL_DIR / JSON_INCLUDE_DIR are ?= so command-line / env wins.
- EXTERNAL_OPENFHE=1 makes config/build skip the local openfhe build step (deps come from the parent install).
- NIOBIUM_CLIENT_FHETCH_DIR and JSON_INCLUDE_DIR are forwarded into the cmake config via conditional -D flags.
- test-fhetch-release forwards EXTERNAL_OPENFHE / JSON_INCLUDE_DIR into niobium-fhetch's Makefile so subsystem tests use the same dep set.

Standalone client builds are unchanged: empty cache vars fall back to vendor/niobium-fhetch and its own openfhe/json submodules.

Bumps vendor/niobium-fhetch to feat/fhetch-into-deps so standalone CI on this branch tests the matching fhetch changes.