### PR TITLE
ci: add SCANOSS license compliance scanning

### DIFF
--- a/.github/workflows/scanoss.yml
+++ b/.github/workflows/scanoss.yml
@@ -5,6 +5,10 @@ on:
     branches: [main, master]
   push:
     branches: [main, master]
+  # Manual rescan from the Actions tab → "SCANOSS License Compliance" → "Run workflow".
+  # Behaves like a push (full scan + ORT trigger). Use this to re-run after
+  # adding/editing .scanoss-curations.json or scanoss.json without bumping a commit.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -47,7 +51,7 @@ jobs:
 
   scanoss-full:
     name: SCANOSS Full Scan (post-merge)
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token
@@ -95,7 +99,7 @@ jobs:
 
   trigger-ort:
     name: Trigger ORT Scan
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: self-hosted
     steps:
       - name: Check if ORT scan needed


### PR DESCRIPTION
## Summary
- Add SCANOSS scan for automated license compliance scanning
- Scans PRs/MRs (delta) and pushes to main (full) for copyleft license violations
- Posts findings as comments — does NOT block merges
- Add `scanoss.json` configuration for component declarations

Part of org-wide compliance initiative.

## Test plan
- [ ] Verify SCANOSS scan runs on next PR/MR
- [ ] Verify no false positives on existing code