### PR TITLE
chore: add SCANOSS license curations (5 need review)

### DIFF
--- a/.scanoss-curations.json
+++ b/.scanoss-curations.json
@@ -1,0 +1,46 @@
+{
+  "curations": {
+    "Fuzzer": {
+      "license": "UNKNOWN",
+      "reviewed": null,
+      "reviewer": null,
+      "note": "Not on GitHub or GitLab: https://gitee.com/local-grpc/Fuzzer"
+    },
+    "PaperFriend-desktop-app": {
+      "license": "UNKNOWN",
+      "reviewed": null,
+      "reviewer": null,
+      "note": "No license found at github.com/CSE201-project/PaperFriend-desktop-app"
+    },
+    "pkcs11_solid": {
+      "license": "UNKNOWN",
+      "reviewed": null,
+      "reviewer": null,
+      "note": "No license found at github.com/AndreanIvan/pkcs11_solid"
+    },
+    "slowfuzz": {
+      "license": "Apache-2.0",
+      "reviewed": "2026-05-01",
+      "reviewer": "auto-known-projects",
+      "note": "Well-known project: SlowFuzz"
+    },
+    "Snake": {
+      "license": "UNKNOWN",
+      "reviewed": null,
+      "reviewer": null,
+      "note": "No license found at github.com/ILTZ/Snake"
+    },
+    "startle": {
+      "license": "MIT",
+      "reviewed": "2026-05-01",
+      "reviewer": "auto-github-api",
+      "note": "License from github.com/raphael-group/startle"
+    },
+    "Task_2": {
+      "license": "UNKNOWN",
+      "reviewed": null,
+      "reviewer": null,
+      "note": "No license found at github.com/VishnenkoMaxim/Task_2"
+    }
+  }
+}


### PR DESCRIPTION
Auto-generated license curations from SCANOSS scan.

**Resolved automatically:** 2 components — no action needed
**Needs manual review:** 5 components (search for `UNKNOWN`)

## What to do

Only entries with `"license": "UNKNOWN"` need action. For each one:
1. Go to the URL in the `note` field
2. Find the project's license (LICENSE, COPYING, or README)
3. Replace `UNKNOWN` with the SPDX ID (e.g. `MIT`, `Apache-2.0`, `GPL-2.0-only`)
4. If it's a false positive, change to `"exclude": true`

Entries with a license already set (e.g. `auto-known-projects`) are resolved — no action needed.

Once merged, the next ORT scan will pick up these curations automatically.