### PR TITLE
Add workflow to auto-bump niobium-haze submodule on main push

### DIFF
--- a/.github/workflows/auto-pr-from-haze.yml
+++ b/.github/workflows/auto-pr-from-haze.yml
@@ -1,0 +1,91 @@
+name: Auto PR — bump niobium-haze submodule
+
+on:
+  repository_dispatch:
+    types: [haze_main_push]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-or-update-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 1
+          submodules: false
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create or update branch
+        id: update
+        env:
+          HAZE_SHA: ${{ github.event.client_payload.sha }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          [[ "$HAZE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "Invalid HAZE_SHA: $HAZE_SHA"; exit 1; }
+
+          git fetch origin main --depth=1
+
+          BRANCH="auto/bump-niobium-haze"
+
+          if git ls-remote --exit-code --heads origin "$BRANCH" > /dev/null 2>&1; then
+            git checkout "$BRANCH"
+          else
+            git checkout -b "$BRANCH" origin/main
+          fi
+
+          git config submodule.vendor/niobium-haze.url "https://x-access-token:${APP_TOKEN}@github.com/NiobiumInc/niobium-haze.git"
+          git submodule update --init vendor/niobium-haze
+          cd vendor/niobium-haze
+          git fetch origin main
+          git checkout "$HAZE_SHA"
+          cd ../..
+
+          git add vendor/niobium-haze
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            git commit -m "chore: bump niobium-haze to ${HAZE_SHA:0:7}"
+            git push origin "$BRANCH" --force-with-lease
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${HAZE_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - name: Create PR if needed
+        if: steps.update.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO_OWNER: ${{ github.repository_owner }}
+        run: |
+          BRANCH="${{ steps.update.outputs.branch }}"
+          SHORT_SHA="${{ steps.update.outputs.short_sha }}"
+          EXISTING=$(gh pr list --head "$BRANCH" --state open --json number -q '.[0].number')
+          if [ -z "$EXISTING" ]; then
+            printf 'Automated submodule bump: tracks the latest commit on [niobium-haze main](https://github.com/%s/niobium-haze/commit/%s).' \
+              "$REPO_OWNER" "${{ github.event.client_payload.sha }}" > /tmp/pr-body.txt
+            gh pr create \
+              --title "Update niobium-haze submodule (${SHORT_SHA})" \
+              --body-file /tmp/pr-body.txt \
+              --base main \
+              --head "$BRANCH"
+          else
+            echo "PR #${EXISTING} already open for ${BRANCH} — updated by push."
+          fi


### PR DESCRIPTION
Adds a repository_dispatch-triggered workflow (haze_main_push) that automatically creates or
updates a PR bumping the vendor/niobium-haze submodule pointer whenever niobium-haze's main branch
receives a new commit.