### PR TITLE
Allow bot-triggered PRs to run claude code reviewer

### DIFF
--- a/.github/workflows/pr-claude-code-review.yml
+++ b/.github/workflows/pr-claude-code-review.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_bots: niobium-ci-bot
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 45
@@ -127,6 +128,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_bots: niobium-ci-bot
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 25


### PR DESCRIPTION
## Summary
  - Add `allowed_bots: niobium-ci-bot` to both the full and partial review jobs in
  `pr-claude-code-review.yml`

  ## Why
  The `claude-code-action` blocks workflows triggered by non-human actors by default. Auto-bump
  submodule PRs opened by `niobium-ci-bot` were failing with:
  > Workflow initiated by non-human actor: niobium-ci-bot (type: Bot). Add bot to allowed_bots list or
   use '*' to allow all bots.