### PR TITLE
fix: use block scalar for run step containing colon-space

### DIFF
--- a/.github/workflows/reusable-submodule-update.yml
+++ b/.github/workflows/reusable-submodule-update.yml
@@ -141,7 +141,8 @@ jobs:
 
       - name: Output PR URL
         if: steps.check-update.outputs.update_needed == 'true' && steps.create-pr.outputs.pull-request-url
-        run: echo "Pull request created or updated: ${{ steps.create-pr.outputs.pull-request-url }}"
+        run: |
+          echo "Pull request created or updated: ${{ steps.create-pr.outputs.pull-request-url }}"
 
       - name: No update needed
         if: steps.check-update.outputs.update_needed == 'false'


### PR DESCRIPTION
## Summary

  - YAML plain scalars cannot contain `: ` (colon-space) — it is ambiguous with mapping key separators
  - The `Output PR URL` step used `run: echo "...: ..."` which triggered a syntax error on line 144
  - Fixed by switching to a block literal (`run: |`) to make the YAML unambiguous