### PR TITLE
Split test-release into test-client-release and fhetch-test CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,25 +137,20 @@ jobs:
           make build-release
 
       # ------------------------------------------------------------
-      # Tests — single aggregate target.
+      # Tests — client-level aggregate only.
       #
-      # test-release runs every Release test known to succeed end-to-end,
-      # both client-level (simple_ops, mult, auto-ciphers) and the
-      # delegated niobium-fhetch submodule tests (simple_fhetch,
-      # fhetch_driver, simple_ops roundtrip). Bootstrap is deliberately
-      # excluded in the Makefile — its primary-side CKKS approximation
-      # error is tracked as a simulator-precision follow-up.
-      #
-      # The client's test-release target forwards OPENFHE_INSTALL_DIR so
-      # the submodule reuses the OpenFHE install we just built here
-      # instead of compiling OpenFHE a second time.
+      # test-client-release covers all client-level Release tests
+      # (simple_ops, mult, auto-ciphers, bootstrap) without delegating
+      # to the niobium-fhetch submodule. The fhetch submodule tests
+      # (test-fhetch-release) are resource-intensive and run separately
+      # on the internal server via test-release.
       # ------------------------------------------------------------
-      - name: Run test-release (client + fhetch submodule)
+      - name: Run test-client-release (client tests — no fhetch submodule)
         run: |
           export CC="ccache gcc"
           export CXX="ccache g++"
           export LD_LIBRARY_PATH="$OPENFHE_ROOT/lib:$LD_LIBRARY_PATH"
-          make test-release
+          make test-client-release
 
       - name: ccache stats
         if: always()
@@ -185,6 +180,128 @@ jobs:
             mult_keys/
             simple_ops_server_workload_*/
             mult_server_workload_*/
+            vendor/niobium-fhetch/simple_ops_keys/
+            vendor/niobium-fhetch/simple_ops_server_workload_*/
+            vendor/niobium-fhetch/fhetch_driver_source_*/
+            vendor/niobium-fhetch/simple_fhetch_example_simple/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  fhetch-test:
+    name: fhetch tests (self-hosted, Release)
+    runs-on: self-hosted
+
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/.cache/ccache
+      OPENMP: OFF
+      NATIVEOPT: OFF
+      OPENFHE_ROOT: ${{ github.workspace }}/vendor/lib/openfhe
+
+    steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: self-hosted-ccache-release-${{ hashFiles('**/CMakeLists.txt', '**/*.cpp', '**/*.h', 'Makefile', 'vendor/niobium-fhetch/Makefile') }}
+          restore-keys: |
+            self-hosted-ccache-release-
+
+      - name: Prime ccache
+        run: |
+          mkdir -p "$CCACHE_DIR"
+          ccache --max-size=4G
+          ccache --zero-stats
+
+      - name: Capture OpenFHE submodule commit
+        id: openfhe_rev
+        run: |
+          cd vendor/niobium-fhetch/vendor/openfhe
+          rev=$(git rev-parse HEAD)
+          echo "rev=$rev" >> "$GITHUB_OUTPUT"
+
+      - name: Restore OpenFHE build
+        id: restore_openfhe
+        uses: actions/cache@v4
+        with:
+          path: |
+            vendor/lib/openfhe
+            vendor/niobium-fhetch/vendor/openfhe/build
+          key: self-hosted-openfhe-release-${{ steps.openfhe_rev.outputs.rev }}
+          restore-keys: |
+            self-hosted-openfhe-release-
+
+      - name: Build OpenFHE
+        run: |
+          export CC="ccache gcc"
+          export CXX="ccache g++"
+
+          TARGETS_FILE="vendor/lib/openfhe/lib/OpenFHE/OpenFHETargets.cmake"
+          if [ -f "$TARGETS_FILE" ] && grep -q "${{ github.workspace }}" "$TARGETS_FILE"; then
+            echo "✓ OpenFHE cache valid for this workspace"
+          else
+            if [ -f "$TARGETS_FILE" ]; then
+              echo "✗ OpenFHE cache has a stale workspace path — rebuilding"
+              rm -rf vendor/lib/openfhe vendor/niobium-fhetch/vendor/openfhe/build
+            fi
+            make config-openfhe-release NATIVEOPT=${NATIVEOPT} OPENMP=${OPENMP}
+            make build-openfhe-release
+          fi
+
+      - name: Configure client
+        run: |
+          export CC="ccache gcc"
+          export CXX="ccache g++"
+          make config-client-release
+
+      - name: Build client
+        run: |
+          export CC="ccache gcc"
+          export CXX="ccache g++"
+          make build-release
+
+      # ------------------------------------------------------------
+      # fhetch submodule tests — run on internal server only.
+      # These are excluded from the GitHub-hosted job (build-and-test)
+      # ------------------------------------------------------------
+      - name: Run test-fhetch-release (fhetch submodule tests)
+        run: |
+          export CC="ccache gcc"
+          export CXX="ccache g++"
+          export LD_LIBRARY_PATH="$OPENFHE_ROOT/lib:$LD_LIBRARY_PATH"
+          make test-fhetch-release
+
+      - name: ccache stats
+        if: always()
+        run: |
+          if command -v ccache >/dev/null 2>&1; then
+            ccache --show-stats
+          else
+            echo "[ccache-stats] ccache not installed — skipping."
+          fi
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fhetch-logs-${{ github.run_attempt }}
+          path: |
+            vendor/niobium-fhetch/build/CMakeFiles/CMakeOutput.log
+            vendor/niobium-fhetch/build/CMakeFiles/CMakeError.log
             vendor/niobium-fhetch/simple_ops_keys/
             vendor/niobium-fhetch/simple_ops_server_workload_*/
             vendor/niobium-fhetch/fhetch_driver_source_*/

--- a/Makefile
+++ b/Makefile
@@ -479,20 +479,19 @@ test-fhetch-release: $(OPENFHE_BUILD_DEP_RELEASE) ## Run the fhetch submodule's 
 	$(MAKE) -C $(FHETCH_DIR) OPENFHE_INSTALL_DIR="$(OPENFHE_INSTALL_DIR)" $(if $(JSON_INCLUDE_DIR),JSON_INCLUDE_DIR="$(JSON_INCLUDE_DIR)") EXTERNAL_OPENFHE=$(EXTERNAL_OPENFHE) test-release
 
 # ==============================================================================
-# test-release — everything that currently passes
+# test-client-release / test-release — Release test aggregates
 # ==============================================================================
-# Aggregates the Release test targets known to succeed end-to-end in
-# both this repo AND the niobium-fhetch submodule:
+# test-client-release — client-level tests only; safe for GitHub-hosted runners.
+#   - test-simple-ops-release      (13 simple_ops, primary decrypt)
+#   - test-mult-release            (CKKS EvalMult, primary decrypt)
+#   - test-auto-ciphers-release    (auto-facade, AUTO_OP defaults to ADD)
+#   - test-bootstrap-release       (client → server → decrypt)
 #
-#   Client-level:
-#     - test-simple-ops-release      (13 simple_ops, primary decrypt)
-#     - test-mult-release            (CKKS EvalMult, primary decrypt)
-#     - test-auto-ciphers-release    (auto-facade, AUTO_OP defaults to ADD)
-#
-#   Submodule-level (via test-fhetch-release):
-#     - simple_fhetch                (FHETCH-only example, no OpenFHE)
-#     - fhetch_driver                (re-drive a .fhetch through the API)
-#     - roundtrip-simple-ops         (13 ops × primary + secondary decrypt)
+# test-release — full suite (client + fhetch submodule); run on internal server only.
+#   Adds via test-fhetch-release:
+#   - simple_fhetch                (FHETCH-only example, no OpenFHE)
+#   - fhetch_driver                (re-drive a .fhetch through the API)
+#   - roundtrip-simple-ops         (13 ops × primary + secondary decrypt)
 #
 # Deliberately excluded:
 #   - bootstrap roundtrip in fhetch (broken)
@@ -500,8 +499,11 @@ test-fhetch-release: $(OPENFHE_BUILD_DEP_RELEASE) ## Run the fhetch submodule's 
 # Override AUTO_OP=MUL AUTO_EXPECTED=21 to exercise the known-failing
 # relin path inside the auto-facade test.
 
-## Run all currently-passing Release tests (this repo + niobium-fhetch submodule)
-test-release: test-simple-ops-release test-mult-release test-auto-ciphers-release test-fhetch-release test-bootstrap-release  
+## Run all client-level Release tests (CI target — no fhetch submodule)
+test-client-release: test-simple-ops-release test-mult-release test-auto-ciphers-release test-bootstrap-release
+
+## Run all currently-passing Release tests (client + fhetch submodule) — internal server only, do not run in CI
+test-release: test-client-release test-fhetch-release
 
 ##@ Cleanup
 


### PR DESCRIPTION
  ## Problem

  `test-fhetch-release` was killing the GitHub-hosted runner when run as
  part of the `test-release` aggregate target.

  ## Changes

  **Makefile**
  - Add `test-client-release`: client-level tests only (simple-ops, mult,
    auto-ciphers, bootstrap) — safe for GitHub-hosted runners.
  - Redefine `test-release` as `test-client-release + test-fhetch-release`.
    Keeps full suite available for manual/internal use but is not run in CI.

  **`.github/workflows/ci.yml`**
  - `build-and-test` job (`ubuntu-latest`): switch from `test-release` to
    `test-client-release`.
  - Add `fhetch-test` job (`self-hosted`): runs `test-fhetch-release` on
    the internal server with its own ccache and OpenFHE cache keys.

  ## Test targets in CI after this PR

  | Target | Runner | Triggered by |
  |---|---|---|
  | `test-client-release` | `ubuntu-latest` | Every push |
  | `test-fhetch-release` | `self-hosted` | Every push |
  | `test-release` | — | Manual only (not in CI) |