### PR TITLE
Add pre-built mode to niobium-client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,22 @@ set(OPENFHE_LIBRARY_PATH "${OPENFHE_INSTALL_DIR}/lib")
 set(NIOBIUM_CLIENT_FHETCH_DIR "" CACHE PATH
     "External niobium-fhetch source tree to use instead of vendor/niobium-fhetch (empty = use vendored submodule)")
 
-if(NIOBIUM_CLIENT_FHETCH_DIR)
+set(NIOBIUM_FHETCH_INSTALL_DIR "" CACHE PATH
+    "Pre-built niobium-fhetch install prefix (lib/libnbfhetch.so + include/niobium/). When set, skips source build entirely. Used by SDK distribution builds.")
+
+if(NIOBIUM_FHETCH_INSTALL_DIR)
+    # Pre-built mode: import installed library directly.
+    # OPENFHE_INSTALL_DIR must point to the same OpenFHE the library was built against.
+    add_library(niobium_fhetch SHARED IMPORTED GLOBAL)
+    set_target_properties(niobium_fhetch PROPERTIES
+        IMPORTED_LOCATION             "${NIOBIUM_FHETCH_INSTALL_DIR}/lib/libnbfhetch.so"
+        INTERFACE_INCLUDE_DIRECTORIES "${NIOBIUM_FHETCH_INSTALL_DIR}/include"
+        INTERFACE_COMPILE_DEFINITIONS "OPENFHE_CPROBES"
+        INTERFACE_LINK_DIRECTORIES    "${OPENFHE_LIBRARY_PATH}"
+        INTERFACE_LINK_LIBRARIES      "OPENFHEpke;OPENFHEcore;OPENFHEbinfhe"
+    )
+    add_library(Niobium::fhetch ALIAS niobium_fhetch)
+elseif(NIOBIUM_CLIENT_FHETCH_DIR)
     add_subdirectory(${NIOBIUM_CLIENT_FHETCH_DIR}
                      ${CMAKE_BINARY_DIR}/_deps/niobium-fhetch-build)
 else()

--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,12 @@ endif
 
 # CMake -D flags that are only emitted when the corresponding override is set.
 # Quote the path so cmake receives a single argument even if it contains spaces.
-CMAKE_CLIENT_FHETCH_DIR_FLAG := $(if $(NIOBIUM_CLIENT_FHETCH_DIR),-DNIOBIUM_CLIENT_FHETCH_DIR="$(NIOBIUM_CLIENT_FHETCH_DIR)")
-CMAKE_JSON_INCLUDE_DIR_FLAG  := $(if $(JSON_INCLUDE_DIR),-DJSON_INCLUDE_DIR="$(JSON_INCLUDE_DIR)")
+CMAKE_CLIENT_FHETCH_DIR_FLAG  := $(if $(NIOBIUM_CLIENT_FHETCH_DIR),-DNIOBIUM_CLIENT_FHETCH_DIR="$(NIOBIUM_CLIENT_FHETCH_DIR)")
+CMAKE_FHETCH_INSTALL_DIR_FLAG := $(if $(NIOBIUM_FHETCH_INSTALL_DIR),-DNIOBIUM_FHETCH_INSTALL_DIR="$(NIOBIUM_FHETCH_INSTALL_DIR)")
+CMAKE_JSON_INCLUDE_DIR_FLAG   := $(if $(JSON_INCLUDE_DIR),-DJSON_INCLUDE_DIR="$(JSON_INCLUDE_DIR)")
+
+# SDK distribution build: root of the extracted SDK tar (default: parent of this client/ dir).
+SDK_DIR ?= $(abspath $(CURDIR)/..)
 
 # OpenMP toggle (OFF by default, override with: make config-openfhe OPENMP=ON)
 OPENMP ?= OFF
@@ -100,6 +104,7 @@ NATIVEOPT ?= OFF
         config config-release build build-release release \
         config-openfhe config-openfhe-release build-openfhe build-openfhe-release \
         config-client config-client-release \
+        sdk-config-release sdk-release \
         install install-release clean clean-all
 
 ##@ Primary Targets
@@ -196,10 +201,28 @@ config-client-release: ## Configure the client + fhetch library + examples (Rele
 		-DCMAKE_BUILD_TYPE=Release \
 		-DOPENFHE_INSTALL_DIR=$(OPENFHE_INSTALL_DIR) \
 		$(CMAKE_CLIENT_FHETCH_DIR_FLAG) \
+		$(CMAKE_FHETCH_INSTALL_DIR_FLAG) \
 		$(CMAKE_JSON_INCLUDE_DIR_FLAG) \
 		-DNIOBIUM_CLIENT_WITH_EXAMPLES=ON \
 		-DCMAKE_INSTALL_PREFIX=$(CLIENT_INSTALL_DIR)
 	@$(call write-build-env,build)
+
+##@ SDK Distribution Build
+
+sdk-config-release: ## Configure against a pre-built Niobium SDK (Release). SDK_DIR defaults to parent directory.
+	$(call set-build-config,Release,build)
+	cmake -S $(CURDIR) -B $(CURDIR)/build \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DOPENFHE_INSTALL_DIR=$(SDK_DIR) \
+		-DNIOBIUM_FHETCH_INSTALL_DIR=$(SDK_DIR)/fhetch \
+		$(CMAKE_JSON_INCLUDE_DIR_FLAG) \
+		-DNIOBIUM_CLIENT_WITH_EXAMPLES=ON \
+		-DCMAKE_INSTALL_PREFIX=$(CLIENT_INSTALL_DIR)
+	@$(call write-build-env,build)
+
+sdk-release: sdk-config-release ## Configure + build against a pre-built Niobium SDK (Release). SDK_DIR defaults to parent directory.
+	$(call set-build-config,Release,build)
+	cmake --build build -j $(NUM_CPUS) --config Release
 
 ##@ Combined Targets
 


### PR DESCRIPTION
- Add `NIOBIUM_FHETCH_INSTALL_DIR` CMake variable. When set, creates an imported `niobium_fhetch` target from pre-built artifacts instead of building from source via `add_subdirectory()`.
- Add `CMAKE_FHETCH_INSTALL_DIR_FLAG` Makefile variable, forwarded to `config-client-release`.                                                                                                                           
- Add `make sdk-release` target: configures and builds against a pre-built Niobium SDK, defaulting `SDK_DIR` to the parent directory (`..`). Intended for use inside the SDK tar distributed to The Fog users. 