### PR TITLE
Fix/auto facade

### DIFF
--- a/src/auto_facade/AutoFacade.cpp
+++ b/src/auto_facade/AutoFacade.cpp
@@ -41,6 +41,14 @@
 bool g_replay_mode = false;
 std::atomic<uint64_t> g_replay_noop_count{0};
 
+// Forward declaration for the loader exposed by libnbfhetch. Declared
+// at top-level (outside the niobium_auto namespace) so the symbol
+// resolves correctly at link time. Implemented in
+// vendor/niobium-fhetch/src/auto_facade.cpp.
+namespace niobium { namespace detail {
+bool load_plaintext_input_file(const std::string& name);
+}}
+
 namespace niobium_auto {
 
 // ---------------------------------------------------------------------------
@@ -83,6 +91,18 @@ static uint64_t g_probe_counter{0};
 // on_deserialize_ciphertext hook gives both runs an identical
 // allocator state (CC + keys loaded, ciphertexts about to be tagged).
 static std::atomic<bool> g_keys_tagged{false};
+
+// Auto-incrementing counter for plaintexts intercepted via on_make_plaintext.
+// The program is deterministic so the Nth Make*Plaintext call gets the same
+// "pt_<N>" name on record and replay — record's tag_input writes
+// <prog>.input_pt_<N>.bin/.ids, and replay's loader reads them back into
+// captured_inputs at the same FHETCH addresses.
+static uint64_t g_plaintext_counter{0};
+
+// Re-entrancy guard: niobium-fhetch's tag/bootstrap paths may transitively
+// trigger Make*Plaintext while we're already in the hook. Without this the
+// counter would race.
+static thread_local bool g_in_make_plaintext_hook = false;
 
 // Track probed ciphertext pointers -> probe name, to avoid double-probing
 // and to let on_decrypt use the same name that on_serialize used.
@@ -566,6 +586,42 @@ bool on_decrypt(lbcrypto::Ciphertext<lbcrypto::DCRTPoly> &ct) {
   }
 
   return false;
+}
+
+void on_make_plaintext(lbcrypto::Plaintext &pt) {
+  // Activate only when the auto-facade is actually driving the run.
+  if (!g_initialized.load(std::memory_order_acquire)) return;
+  if (g_mode == Mode::DORMANT || g_mode == Mode::UNINITIALIZED) return;
+  if (g_in_make_plaintext_hook) return;
+  g_in_make_plaintext_hook = true;
+  struct Guard { ~Guard() { g_in_make_plaintext_hook = false; } } guard;
+
+  // Deterministic name — counter advances in lock-step on record + replay
+  // (program is deterministic, hook fires at every Make*Plaintext site).
+  std::string name = "pt_" + std::to_string(g_plaintext_counter++);
+
+  if (g_mode == Mode::RECORD) {
+    // Real pt: tag it as an input — write .bin/.ids files + push entries
+    // into captured_inputs so the FHETCH simulator finds the plaintext
+    // polynomial values as live-in data.
+    if (pt) {
+      niobium::compiler().tag_input(name, pt);
+    }
+    return;
+  }
+
+  // g_mode == REPLAY: pt is null (cryptocontext.h's Make*Plaintext returns
+  // nullptr in replay as a shortcut). Rehydrate captured_inputs from the
+  // <prog>.input_pt_<N>.bin/.ids files the recording wrote. Addresses on
+  // disk are the record-time FHETCH addresses, which is what the trace
+  // expects.
+  if (::niobium::detail::load_plaintext_input_file(name)) {
+    std::cout << "[niobium_auto] Rehydrated plaintext '" << name
+              << "' from disk for replay\n";
+  } else {
+    std::cerr << "[niobium_auto] Warning: failed to load plaintext '"
+              << name << "' from disk on replay\n";
+  }
 }
 
 } // namespace niobium_auto

--- a/src/auto_facade/AutoFacade.cpp
+++ b/src/auto_facade/AutoFacade.cpp
@@ -502,7 +502,19 @@ void on_deserialize_ciphertext(const std::string &filepath,
       s.erase(0, first);
     return s;
   };
-  const std::string name = unique_name(filepath);
+  // Append a per-filepath load counter so repeated deserializes of the
+  // SAME filepath each get their own `.input_<name>_<N>.bin/.ids` pair
+  // on disk. tag_input<Ciphertext> overwrites the on-disk files on
+  // every call, so without this counter only the LAST load's addr_ids
+  // survive on disk for a given path — even though in-memory
+  // captured_inputs accumulates them all. Cross-process replay reads
+  // disk, so it misses every load except the last. (Hit by FBS's
+  // mat_vec_mult outer-i loop, which reloads each
+  // batch<k>/payload_<j>.bin once per i ∈ [1, MaxNMatch].)
+  static std::unordered_map<std::string, size_t> g_load_counter;
+  const std::string base = unique_name(filepath);
+  size_t n = g_load_counter[base]++;
+  std::string name = base + "_load_" + std::to_string(n);
   niobium::compiler().tag_input(name, ct, filepath);
 }
 

--- a/src/auto_facade/AutoFacade.cpp
+++ b/src/auto_facade/AutoFacade.cpp
@@ -73,6 +73,17 @@ static bool g_recording{false};
 // Auto-incrementing probe counter for Decrypt-time probing
 static uint64_t g_probe_counter{0};
 
+// One-shot flag: tag_keys() must fire at the SAME point in the program
+// on record and replay so the FHETCH compact-address allocator hands
+// key polynomials the same addresses on both runs. Calling it from
+// atexit (record) and ensure_replayed (replay) creates an asymmetry —
+// in record, Eval ops have already consumed many address slots for
+// intermediates by then; in replay, the proxy short-circuits Eval ops
+// so the allocator is still empty. Anchoring tag_keys to the first
+// on_deserialize_ciphertext hook gives both runs an identical
+// allocator state (CC + keys loaded, ciphertexts about to be tagged).
+static std::atomic<bool> g_keys_tagged{false};
+
 // Track probed ciphertext pointers -> probe name, to avoid double-probing
 // and to let on_decrypt use the same name that on_serialize used.
 static std::unordered_map<const void*, std::string> g_probed_cts;
@@ -243,15 +254,9 @@ static void atexit_handler() {
       if (real != g_cc->GetScheme())
         g_cc->SetScheme(real);
     }
-    // Now that user code has finished (and thus loaded keys via
-    // DeserializeEvalMultKey / DeserializeEvalAutomorphismKey), walk the
-    // CC's key maps and tag every DCRTPoly tower into captured_inputs.
-    // tag_keys needs to run *during* the active recording session — once
-    // stop() fires the session ends — so this has to be the last thing
-    // before stop() below.
-    if (g_cc) {
-      niobium::compiler().tag_keys(g_cc);
-    }
+    // tag_keys() already fired lazily in on_deserialize_ciphertext (so
+    // record + replay share an allocator state at key-tag time). Just
+    // close out the recording.
     niobium::compiler().stop();
     g_recording = false;
     // Note: do NOT call replay() here. Replay inside the destructor path
@@ -376,15 +381,14 @@ void on_deserialize_crypto_context(lbcrypto::CryptoContext<lbcrypto::DCRTPoly> &
   if (g_mode == Mode::DORMANT)
     return;
 
-  // Install the proxy scheme only on replay. During recording the real
-  // scheme + OPENFHE_CPROBES probes already capture every operation, and
-  // the proxy's extra ct-mutation path was observed to produce templates
-  // whose sim-reconstructed values decrypt past the CKKS approximation
-  // tolerance for relin-heavy ops like MUL. On replay we need the proxy
-  // so Eval* returns dummies cheaply.
-  if (g_mode == Mode::REPLAY) {
-    cc->SetScheme(std::make_shared<lbcrypto::NiobiumAutoScheme>(cc->GetScheme(), cc));
-  }
+  // Install the NiobiumAutoScheme proxy on both record and replay (matches
+  // the niobium-compiler auto-facade contract). In record the proxy is
+  // a pure passthrough (forwards to m_real); in replay it short-circuits
+  // compute ops to a dummy. A previous workaround installed only on
+  // replay to chase a MUL/relin precision bug — the actual cause was
+  // tag_keys() timing (see below), not the proxy install. Removing the
+  // asymmetry brings the client flow in line with the compiler reference.
+  cc->SetScheme(std::make_shared<lbcrypto::NiobiumAutoScheme>(cc->GetScheme(), cc));
 
   // If auto-facade determined recording mode, start now.
   // The running_p() guard prevents double-starting if Compiler::start() already ran.
@@ -433,6 +437,24 @@ void on_deserialize_ciphertext(const std::string &filepath,
   // is about to write computed output to, which corrupts replay.
   if (g_in_facade_io) return;
 
+  // Tag the eval keys lazily on first user-ciphertext deserialize. By this
+  // point user code has already loaded the CC and the eval keys (cc.bin
+  // and the eval-key files come before the first input ciphertext in every
+  // observed flow); the address allocator state is identical between
+  // record and replay (both have CC tags + key tags only, no intermediates).
+  // Calling tag_keys later (atexit on record / ensure_replayed on replay)
+  // produces asymmetric addresses because record's Eval ops have consumed
+  // many address slots while replay's proxied Eval ops have consumed
+  // zero — the trace then references record-time key addresses that the
+  // replay sim never populated.
+  bool expected = false;
+  if (g_keys_tagged.compare_exchange_strong(expected, true,
+                                            std::memory_order_acq_rel)) {
+    if (g_cc) {
+      niobium::compiler().tag_keys(g_cc);
+    }
+  }
+
   // niobium-fhetch's Compiler doesn't expose cached_input()'s skip-if-present
   // fast path; tag the input unconditionally. The library-side dedup
   // protection in captured_inputs handles accidental double-registration.
@@ -453,16 +475,9 @@ static void ensure_replayed() {
   bool expected = false;
   if (g_replay_done.compare_exchange_strong(expected, true,
                                             std::memory_order_acq_rel)) {
-    // At this point the user's DeserializeEvalMultKey /
-    // DeserializeEvalAutomorphismKey have finished (they run before any
-    // Eval* call that would fire the hooks we arrive through). Tag the
-    // keys now so captured_inputs carries their polynomial values into
-    // Compiler::replay(). Without this, live-in addresses for relin +
-    // rotation key polys stay uninitialized at replay time and any
-    // relin-based op decrypts to noise.
-    if (g_cc) {
-      niobium::compiler().tag_keys(g_cc);
-    }
+    // tag_keys() already fired lazily in on_deserialize_ciphertext so
+    // the FHETCH compact-address allocator handed keys the same
+    // addresses on record and replay. Just run the simulator.
     niobium::compiler().replay();
   }
 }

--- a/src/auto_facade/AutoFacade.cpp
+++ b/src/auto_facade/AutoFacade.cpp
@@ -478,7 +478,31 @@ void on_deserialize_ciphertext(const std::string &filepath,
   // niobium-fhetch's Compiler doesn't expose cached_input()'s skip-if-present
   // fast path; tag the input unconditionally. The library-side dedup
   // protection in captured_inputs handles accidental double-registration.
-  const std::string name = path_stem(filepath);
+  //
+  // Use the full path with separators escaped (so the resulting name is a
+  // single filename-safe token), not just the stem: programs that load
+  // multiple ciphertexts with the same stem from different directories
+  // (e.g. fetch-by-similarity's mat_vec_mult reads batch<j>/row_<i>.bin —
+  // every batch has its own row_0000.bin) would otherwise collide on the
+  // shared name "row_0000", overwriting each other's .bin/.ids files on
+  // disk and losing earlier batches' addresses.
+  auto unique_name = [](const std::string& path) {
+    // Strip trailing .bin (if any) then replace path separators with '_'.
+    std::string s = path;
+    const std::string ext = ".bin";
+    if (s.size() >= ext.size() && s.compare(s.size() - ext.size(), ext.size(), ext) == 0)
+      s.resize(s.size() - ext.size());
+    for (auto& c : s)
+      if (c == '/' || c == '\\' || c == ':' || c == ' ')
+        c = '_';
+    // Drop any leading '_' from absolute paths so the .input_<name>.bin
+    // file doesn't end up named ".input__Users_...".
+    size_t first = s.find_first_not_of('_');
+    if (first != std::string::npos && first > 0)
+      s.erase(0, first);
+    return s;
+  };
+  const std::string name = unique_name(filepath);
   niobium::compiler().tag_input(name, ct, filepath);
 }
 

--- a/tools/nbcc.py
+++ b/tools/nbcc.py
@@ -100,6 +100,24 @@ def parse_args():
     parser.add_argument("--keys-mult", default=None, help="Path to eval mult key")
     parser.add_argument("--keys-auto", default=None, help="Path to eval automorphism key")
 
+    # fhetch_driver mode — on cache-valid runs, replay the recorded trace via
+    # fhetch_driver (which loads inputs from the recorded .bin/.ids files at
+    # their record-time FHETCH addresses) instead of re-executing the target
+    # binary. Works around the auto-facade's cross-process allocator
+    # divergence: re-running the user code in autoscheme mode assigns inputs
+    # different addresses than the trace expects.
+    parser.add_argument("--fhetch-driver", default=None, metavar="PATH",
+                        help="Path to fhetch_driver binary. When set and the "
+                             "trace already exists, exec the driver instead of "
+                             "the target binary (cache-valid replay path).")
+    parser.add_argument("--driver-cc", default=None, metavar="PATH",
+                        help="Path to cc.bin (forwarded to fhetch_driver --cc)")
+    parser.add_argument("--driver-ring-dim", default=None, metavar="N",
+                        help="Ring dimension (forwarded to fhetch_driver --ring-dim)")
+    parser.add_argument("--driver-output", action="append", metavar="NAME:PATH",
+                        help="Output ciphertext to reconstruct (NAME:PATH, repeatable; "
+                             "forwarded to fhetch_driver --output-ct)")
+
     # Compiler flags
     # "local" keeps recording + replay in-process via the FHETCH simulator.
     # Any other value (e.g. "FUNC_SIM", "fpga5.2") tells libnbfhetch's
@@ -175,6 +193,35 @@ def main():
 
     # Set env and exec
     os.environ["NIOBIUM_CONFIG"] = yml_path
+
+    # If --fhetch-driver was supplied and the trace already exists for this
+    # program name, dispatch to the driver to replay the recorded workload
+    # instead of re-executing the target binary. The driver reads .bin/.ids
+    # files written during recording and uses those addresses directly,
+    # sidestepping the auto-facade's allocator divergence on cross-process
+    # replay.
+    if args.fhetch_driver:
+        program_dir = os.path.join(".", args.name)
+        trace_file = os.path.join(program_dir, f"{args.name}.fhetch")
+        if os.path.exists(trace_file):
+            if not args.driver_cc:
+                sys.stderr.write("nbcc.py: --fhetch-driver requires --driver-cc\n")
+                sys.exit(2)
+            if not args.driver_ring_dim:
+                sys.stderr.write("nbcc.py: --fhetch-driver requires --driver-ring-dim\n")
+                sys.exit(2)
+            driver_cmd = [
+                args.fhetch_driver,
+                trace_file,
+                "--ring-dim", args.driver_ring_dim,
+                "--source-dir", program_dir,
+                "--cc", args.driver_cc,
+            ]
+            for spec in args.driver_output or []:
+                driver_cmd += ["--output-ct", spec]
+            print(f"nbcc.py: cache hit, exec fhetch_driver: {' '.join(driver_cmd)}")
+            os.execvp(args.fhetch_driver, driver_cmd)
+
     executable = args.command[0]
     os.execvp(executable, args.command)
 


### PR DESCRIPTION
Four coupled fixes that close the gaps the auto-facade had for workloads heavier than simple_ops: relinearization, plaintext-mid-compute, and ciphertext-reload patterns (all hit by the
  fetch-by-similarity submission, FBS).


  1. auto_facade: fix relin-heavy ops (MUL, EvalMultAndRelinearize, ...) by anchoring tag_keys() to the first ciphertext deserialize
  tag_keys() previously fired at atexit on record and inside ensure_replayed on replay. Asymmetric timing: by atexit the recording's Eval ops had consumed many FHETCH compact-address
  slots, so keys landed at high addresses. On replay the autoscheme short-circuits Eval ops, so when ensure_replayed called tag_keys the allocator was still empty — keys got low
  addresses. Trace referenced record-time addresses; sim loaded key data at different addresses → relin-based ops read wrong values. ADD never touches eval keys so it passed; MUL and
  every relin-heavy op decrypted past tolerance.
  
  1. Fix: hoist tag_keys() into a lazy-once call in on_deserialize_ciphertext. By the time the first input ciphertext is deserialized, CC + eval keys are loaded but no Eval op has run yet
   on either path. Allocator state at tag_keys time matches record vs replay.

  1. Also install NiobiumAutoScheme on both record and replay (was replay-only) — symmetric install matches the niobium-compiler auto-facade contract.
  2. auto_facade: strong on_make_plaintext override — tag on record, rehydrate on replay
  Implements niobium_auto::on_make_plaintext(pt) fired by the OpenFHE-side Make*Plaintext at every plaintext construction site:
    - Bails in DORMANT/UNINITIALIZED modes (manual-SDK programs unaffected).
    - Thread-local re-entrancy guard for transitive Make*Plaintext calls.
    - Counter-based deterministic naming (pt_0, pt_1, ...) so the Nth call has the same name on record and replay.
    - RECORD: compiler().tag_input(name, pt) writes .bin/.ids and populates captured_inputs.
    - REPLAY: pt is null (the cryptocontext.h shortcut returned nullptr); calls niobium::detail::load_plaintext_input_file(name) to rehydrate the recorded plaintext bytes into
  captured_inputs at the recorded FHETCH addresses.
  3. auto_facade: unique input names + fhetch_driver cache-valid dispatch
    - on_deserialize_ciphertext derives the input name from the full filepath (separators escaped, leading underscores trimmed) instead of just the stem. Programs that load multiple
  ciphertexts with the same stem from different directories (e.g. FBS's mat_vec_mult reading batch<j>/row_<i>.bin where every batch has its own row_0000.bin) would otherwise collide on
  the shared name and overwrite each other's .bin/.ids files.
    - nbcc.py --fhetch-driver: when a recorded trace already exists for the target program, exec fhetch_driver against the recorded .bin/.ids files instead of re-running the user binary.
  Sidesteps cross-process allocator divergence. Forwards --driver-cc, --driver-ring-dim, and --driver-output NAME:PATH specs.
  4. auto_facade: number repeated ciphertext loads per filepath
  on_deserialize_ciphertext's previous one-.ids/.bin-per-unique-path scheme: tag_input<Ciphertext> overwrites those files on every call. For programs that reload the same file multiple
  times (FBS's outer-i loop reloads each batch<k>/payload_<j>.bin once per i ∈ [1, MaxNMatch]), only the last load's addr_ids survived on disk, even though in-memory captured_inputs
  accumulates them all. Trace referenced all loads' poly_ids → cross-process replay missed every load except the last.

  4. Append a per-filepath load counter so each deserialize writes its own .input_<base>_load_<N>.{bin,ids}.
