### PR TITLE
Address review feedback on mult transport test

### DIFF
--- a/examples/mult/server.cpp
+++ b/examples/mult/server.cpp
@@ -128,9 +128,11 @@ int main(int argc, char* argv[]) {
                         const auto& sv = sm_towers[t].GetValues();
                         const auto o_mod = ov.GetModulus();
                         const auto s_mod = sv.GetModulus();
-                        if (o_mod.ConvertToInt()  != s_mod.ConvertToInt() ){
-                            std::cout << "shit's fucked at " << t << " openfhe mod" << o_mod << " sim mod " << s_mod << "\n"; 
-                            exit(1);
+                        if (o_mod.ConvertToInt() != s_mod.ConvertToInt()) {
+                            throw std::runtime_error(
+                                "[DIFF] modulus mismatch at tower " + std::to_string(t) +
+                                ": openfhe=" + std::to_string(o_mod.ConvertToInt()) +
+                                " sim=" + std::to_string(s_mod.ConvertToInt()));
                         }
                         size_t diffs = 0;
                         uint64_t first_bad = 0;
@@ -160,7 +162,7 @@ int main(int argc, char* argv[]) {
             }
             std::cout << std::endl;
         };
-        compare_func(ct_openfhe, ct_result);
+        if (ct_openfhe) compare_func(ct_openfhe, ct_result);
 
         if (!Serial::SerializeToFile(keyDir + "/ct_result.bin", ct_result, SerType::BINARY)) {
             std::cerr << "Error: Failed to serialize result ciphertext" << std::endl;
@@ -179,13 +181,13 @@ int main(int argc, char* argv[]) {
             std::cout << "OpenFHE reference ciphertext written to " << keyDir << "/ct_result_openfhe.bin" << std::endl;
         }
 
-        // Deserialze the file we just wrote to see if it is still correct
-        std::cout << "\nRelaod Test \n";
+        // Deserialize the file we just wrote to see if it is still correct
+        std::cout << "\nReload Test\n";
         Ciphertext<DCRTPoly> temp;
         if (!Serial::DeserializeFromFile(keyDir + "/ct_result.bin", temp, SerType::BINARY))
-            throw std::runtime_error("Failed to load ciphertext a");
+            throw std::runtime_error("Failed to reload result ciphertext");
 
-        compare_func(ct_openfhe, temp);
+        if (ct_openfhe) compare_func(ct_openfhe, temp);
     } else {
         std::cerr << "[ERROR] Could not retrieve result" << std::endl;
         return 1;

--- a/scripts/test_transport_mult.sh
+++ b/scripts/test_transport_mult.sh
@@ -74,8 +74,7 @@ echo "=== [1/5] starting fhetch_server (port $PORT) ==="
 PORT="$PORT" BIND=127.0.0.1 \
 NIOBIUM_COMPILER_ROOT="$NIOBIUM_COMPILER_ROOT" \
 NIOBIUM_COMPILER_BUILD="$NIOBIUM_COMPILER_BUILD" \
-"$HERE/fhetch_server.sh" &
-# "$HERE/fhetch_server.sh" > "$SERVER_LOG" 2>&1 &
+"$HERE/fhetch_server.sh" > "$SERVER_LOG" 2>&1 &
 SERVER_PID=$!
 
 # Wait until /healthz answers or the server bails out.
@@ -111,22 +110,20 @@ LD_LIBRARY_PATH="$OPENFHE_LIB" "$mult_server" mult_keys --target="$TARGET"
 
 echo
 echo "=== [4/5] mult_decrypt ==="
-if LD_LIBRARY_PATH="$OPENFHE_LIB" "$mult_decrypt" mult_keys | tee /dev/stderr | grep -q '^\[PASS\]'; then
+if ! LD_LIBRARY_PATH="$OPENFHE_LIB" "$mult_decrypt" mult_keys | tee /dev/stderr | grep -q '^\[PASS\]'; then
   echo
-  echo "=== ✓ transport round-trip PASS ==="
-  # exit 0
-else
-  echo
-  echo "=== ✗ transport round-trip FAIL ==="
-  # exit 1
+  echo "=== ✗ transport round-trip FAIL (decrypt) ==="
+  exit 1
 fi
+echo
+echo "decrypt PASS — continuing to binary comparison"
 
 echo
 echo "=== [5/5] binary comparison ==="
 # Compute the hashes of the result openfhe computed, the result our pipeline writes to the final destination,
-# the ciphertext template the compiler uses, and the serialzied probe of the compiler
+# the ciphertext template the compiler uses, and the serialized probe of the compiler
 OPENFHE_RESULT_HASH=$(sha256sum mult_keys/ct_result_openfhe.bin | awk '{print $1}')
-echo "OpenFHE Gold Standart"
+echo "OpenFHE Gold Standard"
 echo $OPENFHE_RESULT_HASH
 
 FINAL_RESULT_HASH=$(sha256sum mult_keys/ct_result.bin | awk '{print $1}') 


### PR DESCRIPTION
Follow-up to #134, addressing the review.

## Blockers
- `server.cpp`: guard both `compare_func()` calls with `if (ct_openfhe)` so cache-hit runs (recording block skipped) don't dereference a null `shared_ptr`.

## Risks
- `server.cpp`: replace `exit(1)` inside `compare_func` with a `std::runtime_error` throw so RAII destructors and log flushing run on a modulus-mismatch abort.
- `test_transport_mult.sh`: restore the decrypt-failure exit so a decrypt mismatch terminates the script instead of falling through to the binary comparison (which couldn't catch a wrong-but-cached result).
- `test_transport_mult.sh`: restore the server log redirection so `$SERVER_LOG` is actually populated and useful in CI.

## Cleanup
- Profanity removed from a diagnostic string; "Relaod" / "Standart" typos fixed; "Failed to load ciphertext a" error string corrected to "Failed to reload result ciphertext".

## Test plan
- [x] `make test-mult-transport-release` passes (default `FUNC_SIM`)
- [x] `TARGET=FUNC_SIM_HW make test-mult-transport-release` passes
- [x] Both end with `Results are byte identical` / `transport round-trip PASS`