### PR TITLE
dsl_fhe: silence spurious nbc 'undefined name' warnings

### DIFF
--- a/dsl_fhe/xcomp/semantic.py
+++ b/dsl_fhe/xcomp/semantic.py
@@ -93,9 +93,29 @@ class SemanticAnalyzer:
             "vec_zeros": NbType(TypeKind.FN, return_type=UNKNOWN),
             "mat_zeros": NbType(TypeKind.FN, return_type=UNKNOWN),
             "to_matrix_form": NbType(TypeKind.FN, return_type=UNKNOWN),
+            # FHE / cipher built-ins
+            "negate": NbType(TypeKind.FN, return_type=UNKNOWN),
+            "mul_monomial": NbType(TypeKind.FN, return_type=UNKNOWN),
+            "load_model": NbType(TypeKind.FN, return_type=UNKNOWN),
+            "extern_call": NbType(TypeKind.FN, return_type=UNKNOWN),
+            # Casts / scalar helpers
+            "int": NbType(TypeKind.FN, return_type=I64),
+            "str": NbType(TypeKind.FN, return_type=STRING),
+            "abs": NbType(TypeKind.FN, return_type=F64),
+            "tanh": NbType(TypeKind.FN, return_type=F64),
+            # I/O / debug
+            "save": NbType(TypeKind.FN, return_type=VOID),
+            "print": NbType(TypeKind.FN, return_type=VOID),
         }
         for name, ty in builtins.items():
             self.global_scope.define(Symbol(name, ty))
+
+        # Operator-as-value names (e.g. reduce(+, xs) parses the operator as
+        # `op_+`), and the special `scheme` config object plus the scheme-level
+        # literals usable in scheme.override(...). Registered so they don't
+        # surface as spurious "undefined name" warnings.
+        for name in ("op_+", "op_-", "op_*", "op_/", "scheme", "not_set"):
+            self.global_scope.define(Symbol(name, UNKNOWN))
 
     # ===== Entry point =====
 
@@ -205,8 +225,14 @@ class SemanticAnalyzer:
     def _check_stmt(self, stmt: ast.Node):
         if isinstance(stmt, ast.LetStmt):
             val_type = self._check_expr(stmt.value) if stmt.value else UNKNOWN
-            declared_type = self._resolve_type_expr(stmt.type_ann) if stmt.type_ann else val_type
-            self.current_scope.define(Symbol(stmt.name, declared_type))
+            if stmt.tuple_names and len(stmt.tuple_names) > 1:
+                # Destructured binding: let (a, b) = expr — define each name.
+                for n in stmt.tuple_names:
+                    if n != "_":
+                        self.current_scope.define(Symbol(n, UNKNOWN))
+            else:
+                declared_type = self._resolve_type_expr(stmt.type_ann) if stmt.type_ann else val_type
+                self.current_scope.define(Symbol(stmt.name, declared_type))
 
         elif isinstance(stmt, ast.AssignStmt):
             self._check_expr(stmt.target)


### PR DESCRIPTION
Follow-up to #142 (the FHE DSL port). `make` / `nbc check` emitted 9–21
"undefined name" warnings per example — all false positives from the semantic
analyzer not modeling some constructs.

## Fix
- **Destructured `let (a, b) = expr`** previously defined only the first name, so
  the rest (`degree`, `outscale`, `recon`, `predicted`, `marker_idx`, `max_val`,
  …) looked undefined. Now every tuple name is defined (`_` skipped).
- **Register missing built-ins**: `negate`, `mul_monomial`, `load_model`,
  `extern_call`, `int`, `str`, `abs`, `tanh`, `save`, `print`; the
  operator-as-value names (`op_+/-/*//`); and the scheme-override tokens
  `scheme` / `not_set`.

## Result
All five examples now `check` with **0 warnings** (was 9–21 each). Genuinely
undefined names are still reported (`test_undefined_name_warning` passes), and
codegen is unaffected (added symbols are global + untyped; tuple names live in
local scopes the codegen doesn't consult).

🤖 Generated with [Claude Code](https://claude.com/claude-code)