### PR TITLE
chore(gitignore): ignore references and .sandbox scratch dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,9 @@ mult_keys/
 mult_server_workload_*/
 simple_ops_keys/
 simple_ops_server_workload_*/
+
+# Reference material
+references/
+
+# Ephemeral sandbox files
+.sandbox/


### PR DESCRIPTION
Adds ignore entries for local scratch material:

- `references/` — directory-only pattern for vendored reference checkouts.
- `.sandbox/` — ephemeral sandbox files.

`.gitignore` only.