### PR TITLE
fhetch transport: carry optimization level via X-Opt-Level; bump vendored niobium-fhetch

### DIFF
--- a/src/fhetch_transport/client.cpp
+++ b/src/fhetch_transport/client.cpp
@@ -35,6 +35,7 @@ namespace fs = std::filesystem;
 struct Args {
     std::string project;
     std::string target;
+    std::string opt_level;   // O0..O3; empty → server defaults to O0
 };
 
 void print_usage() {
@@ -43,6 +44,8 @@ void print_usage() {
         "\n"
         "  --project=<dir>    fhetch project directory (contains fhetch_replay.json).\n"
         "  --target=<target>  Target device id, forwarded verbatim to the server.\n"
+        "  --opt-level=<lvl>  Optimization level (O0..O3) for the compiler-side\n"
+        "                     replay. Optional; omitted means the server uses O0.\n"
         "\n"
         "Environment:\n"
         "  NBCC_FHETCH_SERVER  Base URL of the replay server. Default http://127.0.0.1:9443.\n";
@@ -56,6 +59,8 @@ Args parse(int argc, char** argv) {
         else if (a == "--project" && i + 1 < argc)    out.project = argv[++i];
         else if (a.rfind("--target=", 0) == 0)        out.target  = a.substr(9);
         else if (a == "--target"  && i + 1 < argc)    out.target  = argv[++i];
+        else if (a.rfind("--opt-level=", 0) == 0)     out.opt_level = a.substr(12);
+        else if (a == "--opt-level" && i + 1 < argc)  out.opt_level = argv[++i];
         else if (a == "-h" || a == "--help") {
             print_usage();
             std::exit(0);
@@ -139,6 +144,10 @@ int main(int argc, char** argv) {
         {nft::kTargetHeader,      args.target},
         {nft::kProjectNameHeader, project_dir.filename().string()},
     };
+    // Only send the opt-level header when the caller asked for one; absent →
+    // the server forwards no -On and the compiler defaults to O0.
+    if (!args.opt_level.empty())
+        headers.emplace(nft::kOptLevelHeader, args.opt_level);
 
     auto res = cli.Post(nft::kReplayPath, headers,
                         request_body, nft::kArchiveContentType);

--- a/src/fhetch_transport/protocol.h
+++ b/src/fhetch_transport/protocol.h
@@ -30,6 +30,11 @@ constexpr const char* kTargetHeader = "X-Target";
 // The server uses this to name the temp working tree and to scope error logs.
 constexpr const char* kProjectNameHeader = "X-Project-Name";
 
+// Optimization level for the compiler-side replay ("O0".."O3"). Optional; when
+// absent the server forwards no -On and the compiler defaults to O0. The server
+// turns this into a native -O<n> flag on the nbcc_fhetch_replay command line.
+constexpr const char* kOptLevelHeader = "X-Opt-Level";
+
 // ---- Defaults ----------------------------------------------------------
 constexpr const char* kDefaultServerEnv  = "NBCC_FHETCH_SERVER";
 constexpr const char* kDefaultServerAddr = "http://127.0.0.1:9443";

--- a/src/fhetch_transport/server.cpp
+++ b/src/fhetch_transport/server.cpp
@@ -100,6 +100,16 @@ bool is_safe_cli_token(const std::string& s) {
     return true;
 }
 
+// Translate an X-Opt-Level header value ("O0".."O3", or bare "0".."3") into the
+// native compiler flag "-O0".."-O3". Returns "" if empty or not a valid level,
+// so the caller can reject malformed values and fall back to the O0 default.
+std::string opt_level_to_flag(const std::string& v) {
+    std::string s = v;
+    if (!s.empty() && (s[0] == 'O' || s[0] == 'o')) s = s.substr(1);
+    if (s.size() == 1 && s[0] >= '0' && s[0] <= '3') return std::string("-O") + s[0];
+    return "";
+}
+
 std::string unique_tempdir(const std::string& prefix) {
     auto base = fs::temp_directory_path();
     for (int attempt = 0; attempt < 64; ++attempt) {
@@ -120,6 +130,7 @@ struct Handler {
         // ---- Header validation ---------------------------------------
         auto target  = req.get_header_value(nft::kTargetHeader);
         auto project = req.get_header_value(nft::kProjectNameHeader);
+        auto opt_in  = req.get_header_value(nft::kOptLevelHeader);
         if (target.empty()) {
             res.status = 400;
             res.set_content("missing header " + std::string(nft::kTargetHeader) + "\n",
@@ -134,6 +145,20 @@ struct Handler {
             return;
         }
         if (project.empty()) project = "niobium_fhetch_project";
+
+        // Optional optimization level → native -O<n>. Absent means O0 (the
+        // compiler-side default); a present-but-malformed value is rejected
+        // rather than silently ignored.
+        std::string opt_flag;
+        if (!opt_in.empty()) {
+            opt_flag = opt_level_to_flag(opt_in);
+            if (opt_flag.empty()) {
+                res.status = 400;
+                res.set_content("header " + std::string(nft::kOptLevelHeader) +
+                                " must be one of O0,O1,O2,O3\n", "text/plain");
+                return;
+            }
+        }
 
         // ---- Unpack the request -------------------------------------
         std::string tempdir;
@@ -157,8 +182,9 @@ struct Handler {
         std::ostringstream cmd;
         cmd << compiler_bin
             << " --project=" << tempdir
-            << " --target="  << target
-            << " 2>&1";
+            << " --target="  << target;
+        if (!opt_flag.empty()) cmd << " " << opt_flag;  // pre-validated -O<n>
+        cmd << " 2>&1";
 
         std::string log;
         int exit_code = -1;


### PR DESCRIPTION
## What

1. **`X-Opt-Level` transport header.** The forwarder accepts `--opt-level` and, when set, sends it as `X-Opt-Level`. The server validates it (`O0..O3`, rejecting malformed values) and appends the corresponding native `-On` to the `nbcc_fhetch_replay` command. Absent header → no `-On`, so the compiler keeps its O0 default. Backward compatible (old server ignores the header; old forwarder ignores the flag).

2. **Bump vendored niobium-fhetch** `d8cc5d2 → 707beef` (main): pulls in the matching `--opt-level` support and the openfhe nb_main bump, so the client SDK's own tree honors the level it forwards.

## Why

Part of the end-to-end "configurable replay optimization level" feature (compiler-side `nbcc_fhetch_replay` + niobium-fhetch dispatch). O0 stays the safe default; O1 is verified correct on the re-recorded FUNC_SIM_HW replay; O2+ enable CSE, not yet correctness-preserving there (tracked separately).