### PR TITLE
dsl_fhe: gate replay on cache-valid runs — fixes fetch returning 0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,13 +181,10 @@ jobs:
           export CXX="ccache g++"
           make -C dsl_fhe test-compiler
           make -C dsl_fhe test-simple test-password test-ml test-nid
-          make -C dsl_fhe fetch-by-similarity   # build/link check (e2e runs below)
 
-      # fetch-by-similarity end-to-end. Its encrypted-replay numeric verify is a
-      # known work-in-progress, so this is non-blocking for now; it still
-      # exercises the full DSL -> generate -> build -> record/replay path.
-      - name: DSL — fetch-by-similarity end-to-end (known WIP, non-blocking)
-        continue-on-error: true
+      # fetch-by-similarity end-to-end (record run): generates the dataset,
+      # records the trace, and verifies all 8 payload vectors decrypt correctly.
+      - name: DSL — fetch-by-similarity end-to-end
         run: |
           python3 -m pip install --user --quiet numpy
           make -C dsl_fhe test-fetch

--- a/dsl_fhe/CLAUDE.md
+++ b/dsl_fhe/CLAUDE.md
@@ -231,11 +231,14 @@ Each `@stage("name")` function generates a `.cpp` with:
    `cache_parameters()`, `set_program_info()`/`set_build_info()`
 4. **Key loading** (server stages) — cc, pk, eval keys from disk (the
    deserialize hooks auto-capture the context and tag the keys)
-5. **Recording bracket** (`@hardware`) — inside the stage function, `start()` is
-   emitted *after* the leading input `load()`s (so the hooks tag inputs first),
-   then `probe()`/`stop()` in `main()`, then `replay()` + `result()` on every run
-6. **Result serialization** — always (the result is rehydrated from the
-   simulator by `result()`)
+5. **Record/replay gate** (`@hardware`) — `main()` branches on
+   `is_cache_valid()`: on a **record** run the stage function executes (with
+   `start()` emitted inside it, after the leading input `load()`s so the hooks
+   tag inputs first), then `probe()`/`stop()`; on a **cache-valid** run zero FHE
+   ops execute — `replay()` runs the cached trace and `result()` reconstructs
+   the output (mirrors the canonical fetch-by-similarity client integration)
+6. **Result serialization** — always: OpenFHE's own output on a record run,
+   the reconstructed ciphertext on a replay run
 
 ### How Match Expressions Compile
 

--- a/dsl_fhe/GRAMMAR.md
+++ b/dsl_fhe/GRAMMAR.md
@@ -462,8 +462,8 @@ RULE hardware-instrumentation:
   (libnbfhetch) record/replay instrumentation:
     1. init() + enable_auto_tagging() + cache parameters from the cache_key list
     2. is_cache_valid() check
-    3. Recording path: start() -> body -> probe() -> stop()
-    4. Replay path (always, local FHETCH simulator): replay() -> result()
+    3. Record path (no cached trace): start() -> body -> probe() -> stop()
+    4. Replay path (cache valid, zero FHE ops): replay() -> result()
   Inputs, evaluation keys, and the crypto context are tagged automatically by the
   instrumented-OpenFHE deserialize hooks (cooperative auto-tagging) — there are no
   generated tag_input() calls. probe() calls are generated from writes() parameters.

--- a/dsl_fhe/Makefile
+++ b/dsl_fhe/Makefile
@@ -286,6 +286,7 @@ test-fetch: fetch-by-similarity
 	@echo "=== Testing fetch-by-similarity (end-to-end, toy instance) ==="
 	@cd $(EXAMPLES)/fetch-by-similarity && \
 		export LD_LIBRARY_PATH=$(LD_LIB_PATH) && \
+		rm -rf *_workload_* fhetch_driver_source_* && \
 		python3 harness/run.py 0 --seed 42
 	@echo ""
 	@echo "All fetch-by-similarity tests passed."

--- a/dsl_fhe/NB_LANGUAGE.md
+++ b/dsl_fhe/NB_LANGUAGE.md
@@ -252,9 +252,11 @@ fn compute(inst: Instance, op: Operation = 0) -> reads(CryptoParams), writes(Enc
 ```
 
 This generates Niobium *client* record/replay instrumentation (`libnbfhetch`):
-`init()` + `enable_auto_tagging()`, a recording path (`start()`/`probe()`/
-`stop()`), and an always-run replay path (`replay()`/`result()`). Inputs, eval
-keys, and the crypto context are tagged automatically by the
+`init()` + `enable_auto_tagging()`, then a gate on `is_cache_valid()` — a
+**record** run executes the computation (`start()`/`probe()`/`stop()`) and
+serializes OpenFHE's own result; a **cache-valid** run executes zero FHE ops and
+reconstructs the output from the cached trace (`replay()`/`result()`). Inputs,
+eval keys, and the crypto context are tagged automatically by the
 instrumented-OpenFHE deserialize hooks (cooperative auto-tagging) — no explicit
 `tag_input`/`tag_keys` calls are emitted.
 

--- a/dsl_fhe/xcomp/codegen.py
+++ b/dsl_fhe/xcomp/codegen.py
@@ -1108,17 +1108,49 @@ endforeach()
         args_str = ", ".join(call_args)
 
         has_return = self._fn_has_return(stage.fn)
-        if has_return:
-            self.wl(f"auto result = {fn_name}({args_str});")
-        else:
-            self.wl(f"{fn_name}({args_str});")
-
-        # Niobium recording stop
         if stage.hardware:
-            self._gen_niobium_record_stop(stage, has_result=has_return)
+            # Record/replay gate — mirrors the canonical client integration
+            # (fetch-by-similarity NIOBIUM_INTEGRATION.md): ALL FHE ops run only
+            # on the record pass, which serializes OpenFHE's own result; a
+            # cache-valid run executes ZERO FHE ops and reconstructs the output
+            # from the cached trace via replay()/result().
+            self.wl("const bool _nb_replaying = niobium::compiler().is_cache_valid();")
+            if has_return:
+                wire = self._stage_result_wire(stage)
+                result_type = wire.name if wire else "Ciphertext<DCRTPoly>"
+                self.wl(f"{result_type} result;")
+            self.wl("if (!_nb_replaying) {")
+            self.indent()
+            if has_return:
+                self.wl(f"result = {fn_name}({args_str});")
+            else:
+                self.wl(f"{fn_name}({args_str});")
+            if has_return:
+                self._gen_result_io(stage, "probe")
+            self.wl("niobium::compiler().stop();")
+            self.wl("niobium::compiler().enable_hollow_mode(false);")
+            self.dedent()
+            self.wl("} else {")
+            self.indent()
+            self.wl('std::cout << "[nb] Cached trace found — replaying (no FHE ops)" << std::endl;')
+            self.wl("if (!niobium::compiler().replay()) {")
+            self.indent()
+            self.wl('std::cerr << "[ERROR] FHETCH replay failed!" << std::endl;')
+            self.wl("return 1;")
+            self.dedent()
+            self.wl("}")
+            if has_return:
+                self._gen_result_io(stage, "rehydrate")
+            self.dedent()
+            self.wl("}")
+        else:
+            if has_return:
+                self.wl(f"auto result = {fn_name}({args_str});")
+            else:
+                self.wl(f"{fn_name}({args_str});")
 
-        # Save result. For hardware stages the result was just rehydrated from
-        # the FHETCH simulator by result(); serialize it like any other.
+        # Save result — on a record run this is OpenFHE's own output; on a
+        # replay run it was reconstructed from the cached trace.
         if has_return:
             self._gen_result_serialization(stage)
 
@@ -1460,31 +1492,6 @@ endforeach()
         # hooks capture the context (on cc.bin load above), tag the eval keys,
         # and tag each input ciphertext as it is deserialized — at deterministic
         # points that keep record/replay addresses aligned.
-
-    def _gen_niobium_record_stop(self, stage: StageInfo, has_result: bool = True):
-        # On the recording run, probe the outputs and finalize the trace. Then,
-        # on every run, replay through the FHETCH simulator and rehydrate the
-        # result ciphertexts from their probes. `result` is declared at main
-        # scope by _gen_main, so it is visible both here and for serialization.
-        self.wl("if (!niobium::compiler().is_cache_valid()) {")
-        self.indent()
-        if has_result:
-            self._gen_result_io(stage, "probe")
-        self.wl("niobium::compiler().stop();")
-        self.wl("niobium::compiler().enable_hollow_mode(false);")
-        self.dedent()
-        self.wl("}")
-        self.blank()
-
-        self.wl('std::cout << "[nb] Replaying through FHETCH simulator" << std::endl;')
-        self.wl("if (!niobium::compiler().replay()) {")
-        self.indent()
-        self.wl('std::cerr << "[ERROR] FHETCH replay failed!" << std::endl;')
-        self.wl("return 1;")
-        self.dedent()
-        self.wl("}")
-        if has_result:
-            self._gen_result_io(stage, "rehydrate")
 
     def _stage_result_wire(self, stage: StageInfo):
         """Return the wire definition this stage writes (for probe/rehydrate)."""

--- a/dsl_fhe/xcomp/tests/test_codegen.py
+++ b/dsl_fhe/xcomp/tests/test_codegen.py
@@ -96,6 +96,14 @@ def test_stage_with_hardware():
     assert "Target" not in cpp
     assert "global_key_cache" not in cpp
     assert "niobium_hw" not in cpp
+    # Record/replay gate: ALL FHE ops on the record pass only; replay()/result()
+    # exclusively in the cache-valid else-branch (zero FHE ops). The record run
+    # must serialize OpenFHE's own result — replay must NOT run after recording
+    # in the same pass (that overwrote correct results with sim output).
+    assert "const bool _nb_replaying = niobium::compiler().is_cache_valid();" in cpp
+    record_branch = cpp.split("if (!_nb_replaying) {")[1].split("} else {")[0]
+    assert "replay()" not in record_branch
+    assert "stop()" in record_branch
 
 
 def test_bool_param_flag():


### PR DESCRIPTION
## Root cause

Compared our generated code against the working client-API integration in the
`fetch-by-similarity` repo (`oss_release` branch, `NIOBIUM_INTEGRATION.md`). The
library code is identical (its pinned client/fhetch matches our `main`); the
difference was **structural** in the generated `main()`:

- **Reference (works)**: gate on `is_cache_valid()` — a **record** run executes the
  FHE computation and serializes **OpenFHE's own result** (no replay); a
  **cache-valid** run executes **zero FHE ops** and reconstructs the output via
  `replay()`/`result()`. ("All FHE ops inside the `is_cache_valid()` gate.")
- **Ours (returned 0)**: recorded, then immediately called `replay()`/`result()`
  **in the same run**, overwriting the correct OpenFHE output with the simulator
  reconstruction — zeros for fetch's 1.57M-instruction trace.

## Change

Generated `@hardware` `main()` now mirrors the reference exactly:

```cpp
const bool _nb_replaying = niobium::compiler().is_cache_valid();
EncryptedResult result;
if (!_nb_replaying) { result = compute(...); probe(...); stop(); }
else { /* zero FHE ops */ replay(); result(cc, "result", result.ciphertext); }
serialize(result);
```

- `test-fetch` clears stale recorded traces first (deterministic record run).
- CI's fetch e2e step is now **blocking** (was `continue-on-error` "known WIP").
- Docs (CLAUDE/GRAMMAR/NB_LANGUAGE) updated; codegen test asserts `replay()`
  cannot appear in the record branch.

## Verification

- **fetch-by-similarity: `[harness] PASS (All 8 payload vectors match)`** (was 0)
- simple / password-retrieval / ml-inference / fhe-NetworkMonitor all pass
- simple's **replay** run (run 2, cache hit, zero FHE ops) reconstructs correct
  values (8 / 15)
- 18/18 codegen unit tests

## Known remaining

Fetch's *replay* run (second invocation, cache hit) still reconstructs zeros —
a sim-side reconstruction issue on very large traces, now isolated from the
record path and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)