### PR TITLE
dsl_fhe: add set-membership example (private name matching)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
           export CC="ccache gcc"
           export CXX="ccache g++"
           make -C dsl_fhe test-compiler
-          make -C dsl_fhe test-simple test-password test-ml test-nid
+          make -C dsl_fhe test-simple test-password test-set-membership test-ml test-nid
 
       # fetch-by-similarity end-to-end (record run): generates the dataset,
       # records the trace, and verifies all 8 payload vectors decrypt correctly.

--- a/dsl_fhe/CLAUDE.md
+++ b/dsl_fhe/CLAUDE.md
@@ -10,6 +10,7 @@ make simple                 # Build just the simple example
 make fetch-by-similarity    # Build the fetch-by-similarity example
 make fhe-network-monitor    # Build the KitNET anomaly detection example
 make ml-inference           # Build the ML inference example
+make set-membership         # Build the private name-matching example
 ```
 
 ## Documentation Map
@@ -384,6 +385,10 @@ dsl_fhe/
       shared.nb, client.nb, server.nb
       nb_out/                        # Generated C++ + build
       README.md                      # Design rationale and usage guide
+    set-membership/                  # Private name matching (exact + Soundex fuzzy)
+      shared.nb, client.nb, server.nb
+      harness/encode_names.py        # Plaintext name encoding -> dataset.bin/query.bin
+      nb_out/                        # Generated C++ + build
 ```
 
 ## Adding a New Example

--- a/dsl_fhe/Makefile
+++ b/dsl_fhe/Makefile
@@ -18,6 +18,7 @@ NIOBIUM_CLIENT_ROOT ?= $(realpath $(CURDIR)/..)
 SUBMISSION_REPO ?=
 
 .PHONY: test-compiler examples fetch-by-similarity simple fhe-network-monitor ml-inference \
+       set-membership test-set-membership \
        password-retrieval test-simple test-fetch test-nid test-ml test-password test-examples \
        clean help
 
@@ -59,6 +60,10 @@ test-compiler:
 	@cd $(XCOMP) && python3 nbc.py parse ../$(EXAMPLES)/password-retrieval/client.nb  > /dev/null
 	@cd $(XCOMP) && python3 nbc.py parse ../$(EXAMPLES)/password-retrieval/server.nb  > /dev/null
 	@echo "  PASS  parse password-retrieval/*.nb"
+	@cd $(XCOMP) && python3 nbc.py parse ../$(EXAMPLES)/set-membership/shared.nb  > /dev/null
+	@cd $(XCOMP) && python3 nbc.py parse ../$(EXAMPLES)/set-membership/client.nb  > /dev/null
+	@cd $(XCOMP) && python3 nbc.py parse ../$(EXAMPLES)/set-membership/server.nb  > /dev/null
+	@echo "  PASS  parse set-membership/*.nb"
 	@echo ""
 	@echo "=== End-to-end: semantic check ==="
 	@cd $(XCOMP) && python3 nbc.py check \
@@ -81,6 +86,10 @@ test-compiler:
 		../$(EXAMPLES)/password-retrieval/shared.nb \
 		../$(EXAMPLES)/password-retrieval/client.nb \
 		../$(EXAMPLES)/password-retrieval/server.nb
+	@cd $(XCOMP) && python3 nbc.py check \
+		../$(EXAMPLES)/set-membership/shared.nb \
+		../$(EXAMPLES)/set-membership/client.nb \
+		../$(EXAMPLES)/set-membership/server.nb
 	@echo ""
 	@echo "All tests passed."
 
@@ -93,7 +102,7 @@ test-compiler:
 # but don't produce real results (real model/weights need the submission; see
 # each example's data/README.md). test-examples runs only the examples that
 # produce meaningful, verifiable output.
-examples: simple fetch-by-similarity ml-inference fhe-network-monitor password-retrieval test-examples
+examples: simple fetch-by-similarity ml-inference fhe-network-monitor password-retrieval set-membership test-examples
 
 # --- fetch-by-similarity ---
 
@@ -225,6 +234,27 @@ endif
 
 PWD_NB_OUT := $(EXAMPLES)/password-retrieval/nb_out
 
+# --- set-membership (private name matching) ---
+
+SETM_NB_OUT := $(EXAMPLES)/set-membership/nb_out
+
+set-membership:
+	@echo "=== Compiling set-membership (DSL → C++) ==="
+	@mkdir -p $(SETM_NB_OUT)
+	@cd $(XCOMP) && python3 nbc.py compile \
+		../$(EXAMPLES)/set-membership/shared.nb \
+		../$(EXAMPLES)/set-membership/client.nb \
+		../$(EXAMPLES)/set-membership/server.nb \
+		--outdir ../$(SETM_NB_OUT)
+	@echo ""
+	@echo "=== Building set-membership (C++ → binaries) ==="
+	@mkdir -p $(SETM_NB_OUT)/build
+	@cd $(SETM_NB_OUT)/build && \
+		cmake .. -DNIOBIUM_CLIENT_ROOT=$(NIOBIUM_CLIENT_ROOT) && \
+		$(MAKE) -j$(NPROC) 2>&1
+	@echo ""
+	@echo "Built binaries in $(SETM_NB_OUT)/build/"
+
 password-retrieval:
 	@echo "=== Compiling password-retrieval (DSL → C++) ==="
 	@mkdir -p $(PWD_NB_OUT)
@@ -339,7 +369,34 @@ test-password: password-retrieval
 		rm -rf io && \
 		echo "" && echo "All password-retrieval tests passed."
 
-test-examples: test-simple test-fetch test-password
+test-set-membership: set-membership
+	@echo ""
+	@echo "=== Testing set-membership (end-to-end) ==="
+	@cd $(EXAMPLES)/set-membership && \
+		export LD_LIBRARY_PATH=$(LD_LIB_PATH) && \
+		rm -rf io *_workload_* fhetch_driver_source_* && \
+		B=nb_out/build && \
+		echo "  exact: query 'James Smith' (in dataset)..." && \
+		python3 harness/encode_names.py 0 --query "James Smith" && \
+		$$B/key_generation 0 && $$B/encrypt_query 0 && $$B/compute 0 && \
+		$$B/decrypt_verify 0 1.0 && \
+		echo "  PASS  exact match → score ≈ 1" && \
+		echo "  exact: query 'Zelda Quixote' (not in dataset)..." && \
+		rm -rf *_workload_* fhetch_driver_source_* && \
+		python3 harness/encode_names.py 0 --query "Zelda Quixote" && \
+		$$B/encrypt_query 0 && $$B/compute 0 && \
+		$$B/decrypt_verify 0 0.0 && \
+		echo "  PASS  no match → score ≈ 0" && \
+		echo "  soundex: fuzzy query 'Robbrt Johnson' (10 'Robert *' collisions)..." && \
+		rm -rf *_workload_* fhetch_driver_source_* && \
+		python3 harness/encode_names.py 1 --query "Robbrt Johnson" && \
+		$$B/key_generation 1 && $$B/encrypt_query 1 && $$B/compute 1 && \
+		$$B/decrypt_verify 1 10.0 && \
+		echo "  PASS  soundex fuzzy match → score ≈ 10" && \
+		rm -rf io *_workload_* fhetch_driver_source_* && \
+		echo "" && echo "All set-membership tests passed."
+
+test-examples: test-simple test-fetch test-password test-set-membership
 	@echo ""
 	@echo "All example tests passed."
 
@@ -353,6 +410,7 @@ clean:
 	cd $(FETCH_NB_OUT) && \
 		find . -maxdepth 1 -type f ! -name utils.h ! -name .gitignore -delete 2>/dev/null; true
 	rm -rf $(SIMPLE_NB_OUT)
+	rm -rf $(SETM_NB_OUT) $(EXAMPLES)/set-membership/io
 	rm -rf $(NID_NB_OUT)/build
 	cd $(NID_NB_OUT) && \
 		find . -maxdepth 1 -type f ! -name .gitignore -delete 2>/dev/null; true

--- a/dsl_fhe/README.md
+++ b/dsl_fhe/README.md
@@ -157,6 +157,12 @@ dsl_fhe/
       server.nb                        # Per-question Chebyshev match + password gate (84 lines)
       README.md                        # Design rationale and usage guide
       nb_out/                          # Generated C++ + build
+    set-membership/                    # Private name matching (compilable, runnable)
+      shared.nb                        # Profiles (exact/soundex), wire types
+      client.nb                        # Keygen, per-position query encryption, decrypt+threshold
+      server.nb                        # Squared-distance + iterated-squaring indicator
+      harness/encode_names.py          # Plaintext name encoding (exact + Soundex)
+      nb_out/                          # Generated C++ + build
     simple/                            # Basic cipher operations (compilable, runnable)
       shared.nb                        # Operation enum (25 ops), instance sizes
       client.nb                        # Encrypt two scalars, decrypt+verify
@@ -195,11 +201,13 @@ make fetch-by-similarity    # Build fetch-by-similarity (8 binaries)
 make fhe-network-monitor    # Build KitNET anomaly detection (4 binaries)
 make ml-inference           # Build ML inference (4 binaries)
 make password-retrieval     # Build password retrieval (5 binaries)
+make set-membership         # Build private name matching (4 binaries)
 make test-simple            # End-to-end: 8 FHE operations verified
 make test-fetch             # End-to-end: toy fetch pipeline
 make test-nid               # End-to-end: toy KitNET (keygen+encrypt+inference)
 make test-ml                # End-to-end: keygen+encrypt+compute (single)
 make test-password          # End-to-end: correct + wrong answer verification
+make test-set-membership    # End-to-end: exact match, no-match, Soundex fuzzy
 make test-examples          # Run all end-to-end tests
 ```
 
@@ -438,6 +446,38 @@ together for exponentially better discrimination than a single aggregate compari
 cd dsl_fhe && make test-password
 # Runs: key_generation 0 && setup_record 0 && submit_query 0 && verify 0 && decrypt_result 0
 # Then: submit_query 0 7 3 9 1 8 (wrong) && verify 0 && decrypt_result 0 0.0
+```
+
+### `set-membership/` — Private Name Matching
+
+Privacy-preserving set membership (a port of the `openfhe-set-membership`
+workload): given a client's private name and a server's private dataset of
+names, determine whether the name appears in the dataset — without revealing
+the query to the server or the dataset to the client.
+
+Names are encoded outside the circuit (`harness/encode_names.py`) as
+fixed-length integer vectors (a–z → 1..26, zero-padded) — raw characters in
+**Exact** mode (L=20) or **Soundex** phonetic hashes in fuzzy mode (L=4, so
+"Robbrt" matches "Robert"). The CKKS circuit computes, per SIMD slot (one
+dataset name per slot):
+
+1. squared Euclidean distance to the query, per character position — 1 level
+2. normalize by C = 26²·L and complement: `t = 1 − S/C` — 1 level
+3. **iterated squaring** `t^(2^K)`: matches stay ≈ 1, non-matches decay to ≈ 0 — K levels
+4. slot-sum: the aggregate score ≈ the number of matching names
+
+The client decrypts the score and thresholds at 0.5. Depth = 2 + K (K=16
+exact, K=14 Soundex), chosen so the worst non-match indicator falls below 0.01.
+
+- One ciphertext per character position, the query character replicated in all slots
+- Dataset stays plaintext on the server (column-major packing), folded in via `ct − plaintext_vector`
+- Demonstrates: per-instance `scheme.override(depth:)`, ct−vector ops, `slot_sum`, multi-batch accumulation
+
+```bash
+cd dsl_fhe && make test-set-membership
+# exact:   'James Smith'   in dataset  → score ≈ 1
+# exact:   'Zelda Quixote' not present → score ≈ 0 (7e-15)
+# soundex: 'Robbrt Johnson' fuzzy      → score ≈ 10 (all 'Robert *' collide)
 ```
 
 ### `fhe-NetworkMonitor/` — KitNET Anomaly Detection

--- a/dsl_fhe/examples/set-membership/client.nb
+++ b/dsl_fhe/examples/set-membership/client.nb
@@ -1,0 +1,102 @@
+// client.nb — Client-side stages for private set-membership
+//============================================================================
+// Runs on the CLIENT machine (owns the secret key).
+// Compiles to:
+//   key_generation  <profile>
+//   encrypt_query   <profile>
+//   decrypt_verify  <profile> [expected_score]
+//
+// Profiles: 0=Exact (toy ring), 1=Soundex (toy ring), 2=ExactFull
+//============================================================================
+
+use shared::*
+
+// ============================================================================
+// Scheme configuration
+//
+// CKKS, depth = 2 + K (one level each for the distance squaring and the
+// normalization scalar multiply, plus K iterated squarings). The per-profile
+// depth comes from the Instance via scheme.override below.
+// ============================================================================
+
+scheme CKKS {
+    security: 128-classic    // toy profiles override to not_set below
+    key_dist: uniform_ternary
+    scaling: flexible_auto
+    precision: 50
+    first_mod: 60
+    depth: 18
+}
+
+requires { add, mul }
+
+// ============================================================================
+// Stage 1: Key generation
+// ============================================================================
+
+@client @stage("key_generation")
+fn generate_keys(inst: Instance) -> writes(CryptoParams)
+{
+    scheme.override(depth: inst.depth)
+
+    if inst.profile == Exact {
+        scheme.override(security: not_set)    // toy ring for fast runs
+    }
+    if inst.profile == Soundex {
+        scheme.override(security: not_set)
+    }
+
+    let keys = keygen()
+    save_secret_key(keys.secret, keydir(inst) / "sk.bin")
+
+    return CryptoParams {
+        context: keys.context,
+        public_key: keys.public,
+        eval_mult_key: keys.eval_mult,
+    }
+}
+
+// ============================================================================
+// Stage 2: Encrypt the query name
+//
+// query.bin holds the encoded query replicated to n_slots rows (one column
+// per character position), so each column encrypts to a ciphertext with the
+// position's character code in every SIMD slot.
+// ============================================================================
+
+@client @stage("encrypt_query")
+fn encrypt_query(inst: Instance) -> reads(CryptoParams), writes(EncryptedName)
+{
+    let params = load(CryptoParams, from: keydir(inst))
+    let qmat = load_matrix<f64>(query_file(inst), inst.name_len)
+
+    return EncryptedName {
+        positions: for pos in 0..inst.name_len {
+            let column = qmat[0..inst.n_slots, pos]
+            encrypt(params.public_key, column)
+        }
+    }
+}
+
+// ============================================================================
+// Stage 3: Decrypt and verify the aggregate match score
+//
+// Each matching dataset name contributes ~1.0 to the score; each non-match
+// decays to ~0 after iterated squaring. expected is the number of matches
+// the harness computed in cleartext (0.0 or 1.0 for the test queries).
+// ============================================================================
+
+@client @stage("decrypt_verify")
+fn decrypt_verify(inst: Instance, expected: f64 = 1.0) -> reads(EncryptedResult)
+{
+    let sk = load_secret_key(keydir(inst) / "sk.bin")
+    let encrypted = load(EncryptedResult, from: encdir(inst))
+
+    let result = decrypt(sk, encrypted.score)
+    let value = result[0]
+
+    print(value)
+
+    let tolerance = 0.3
+    assert abs(value - expected) < tolerance
+}

--- a/dsl_fhe/examples/set-membership/harness/encode_names.py
+++ b/dsl_fhe/examples/set-membership/harness/encode_names.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# Copyright 2024-present Niobium Microsystems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Plaintext preprocessing for the set-membership example.
+
+Encodes the server's name dataset and the client's query name into the binary
+matrices the DSL stages load (everything string-shaped happens here; the FHE
+circuit only sees fixed-length numeric vectors):
+
+  io/<profile>/dataset.bin — row-major float64, (padded_rows x L); one encoded
+      name per row, rows zero-padded to a multiple of n_slots (a zero row can
+      never match a real query: real first characters encode to 1..26).
+  io/<profile>/query.bin   — float64 (n_slots x L): the encoded query
+      replicated down each column, so each column encrypts to a ciphertext
+      with that position's character code in every SIMD slot.
+
+Encoding (mirrors the original openfhe-set-membership preprocessing):
+  Exact   — lowercase, strip non-letters, a-z -> 1..26, pad/truncate to L=20.
+  Soundex — phonetic hash (letter + 3 digits, e.g. Robert -> R163), L=4.
+
+Prints the cleartext expected match count (the FHE score the client should
+decrypt) so tests can pass it to decrypt_verify.
+
+Usage:
+  encode_names.py PROFILE --query NAME [--dataset FILE]
+    PROFILE: 0=Exact (toy)  1=Soundex (toy)  2=ExactFull
+  Without --dataset, a deterministic built-in sample of common first+last
+  name combinations is used.
+"""
+import argparse
+import struct
+import sys
+from pathlib import Path
+
+# (profile_name, n_slots, name_len) per profile — must mirror shared.nb
+PROFILES = {
+    0: ("exact", 1024, 20),
+    1: ("soundex", 1024, 4),
+    2: ("exact_full", 32768, 20),
+}
+
+EXAMPLE_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ── Name encoding (exact + Soundex) ─────────────────────────────────────
+
+def letters_only(s: str) -> str:
+    return "".join(c for c in s if c.isalpha())
+
+
+SOUNDEX_CODES = {
+    **dict.fromkeys("BFPV", "1"), **dict.fromkeys("CGJKQSXZ", "2"),
+    **dict.fromkeys("DT", "3"), "L": "4", **dict.fromkeys("MN", "5"), "R": "6",
+}
+
+
+def soundex(name: str) -> str:
+    alpha = letters_only(name)
+    if not alpha:
+        return "A000"
+    result = alpha[0].upper()
+    prev = SOUNDEX_CODES.get(alpha[0].upper(), "0")
+    for c in alpha[1:]:
+        if len(result) >= 4:
+            break
+        code = SOUNDEX_CODES.get(c.upper(), "0")
+        if code != "0" and code != prev:
+            result += code
+        prev = code
+    return (result + "000")[:4]
+
+
+def encode_char(c: str) -> int:
+    if "a" <= c <= "z":
+        return ord(c) - ord("a") + 1
+    if "A" <= c <= "Z":
+        return ord(c) - ord("A") + 1
+    if "0" <= c <= "9":
+        return ord(c) - ord("0")
+    return 0
+
+
+def encode_name(name: str, soundex_mode: bool, name_len: int) -> list[int]:
+    processed = soundex(name) if soundex_mode else letters_only(name).lower()
+    enc = [0] * name_len
+    for i, c in enumerate(processed[:name_len]):
+        enc[i] = encode_char(c)
+    return enc
+
+
+# ── Built-in sample dataset ──────────────────────────────────────────────
+# Deterministic combinations of common US first/last names (public census
+# data) — a stand-in for the server's private dataset.
+
+FIRST = ["James", "Mary", "Robert", "Patricia", "John", "Jennifer", "Michael",
+         "Linda", "David", "Elizabeth", "William", "Barbara", "Richard",
+         "Susan", "Joseph", "Jessica", "Thomas", "Sarah", "Charles", "Karen"]
+LAST = ["Smith", "Johnson", "Williams", "Brown", "Jones", "Garcia", "Miller",
+        "Davis", "Rodriguez", "Martinez"]
+
+
+def sample_names() -> list[str]:
+    return [f"{FIRST[i % len(FIRST)]} {LAST[(i // len(FIRST)) % len(LAST)]}"
+            for i in range(188)]
+
+
+# ── Binary writers ───────────────────────────────────────────────────────
+
+def write_doubles(path: Path, rows: list[list[float]]):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "wb") as f:
+        for r in rows:
+            f.write(struct.pack(f"<{len(r)}d", *r))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("profile", type=int, choices=sorted(PROFILES))
+    ap.add_argument("--query", required=True, help="name to search for")
+    ap.add_argument("--dataset", help="text file, one name per line "
+                                      "(default: built-in sample)")
+    args = ap.parse_args()
+
+    pname, n_slots, name_len = PROFILES[args.profile]
+    soundex_mode = args.profile == 1
+    iodir = EXAMPLE_ROOT / "io" / pname
+
+    if args.dataset:
+        names = [ln.strip() for ln in open(args.dataset) if ln.strip()]
+    else:
+        names = sample_names()
+
+    encoded = [encode_name(n, soundex_mode, name_len) for n in names]
+    query = encode_name(args.query, soundex_mode, name_len)
+
+    # Dataset: zero-pad rows to a multiple of n_slots
+    padded = -(-len(encoded) // n_slots) * n_slots
+    rows = [[float(v) for v in e] for e in encoded]
+    rows += [[0.0] * name_len] * (padded - len(encoded))
+    write_doubles(iodir / "dataset.bin", rows)
+
+    # Query: replicated to n_slots rows
+    write_doubles(iodir / "query.bin", [[float(v) for v in query]] * n_slots)
+
+    expected = sum(1 for e in encoded if e == query)
+    mode = "soundex" if soundex_mode else "exact"
+    print(f"encoded {len(names)} names ({padded} padded rows, {mode}, L={name_len}) "
+          f"-> {iodir}")
+    print(f"query {args.query!r} expected matches: {expected}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dsl_fhe/examples/set-membership/server.nb
+++ b/dsl_fhe/examples/set-membership/server.nb
@@ -1,0 +1,62 @@
+// server.nb — Server-side encrypted set-membership evaluation
+//============================================================================
+// Runs on the SERVER machine. NO access to secret key. The dataset is the
+// server's PRIVATE data — loaded as a plaintext matrix here and folded into
+// the homomorphic circuit; it never leaves the server, and the client's
+// query is never decrypted.
+// Compiles to:
+//   compute <profile>
+//============================================================================
+
+use shared::*
+
+// ============================================================================
+// Encrypted evaluation: squared distance + iterated-squaring indicator
+//
+// For each batch of n_slots dataset names (one name per SIMD slot):
+//   acc   = sum_pos (query[pos] - dataset_column[pos])^2        [1 level]
+//   ct_t  = 1 - acc/C                                            [1 level]
+//   ct_t  = ct_t^(2^K)        (K squarings amplify the gap)      [K levels]
+//   score += slot_sum(ct_t)   (matches contribute ~1 each)
+// ============================================================================
+
+@server @stage("compute")
+@hardware(cache_key: ["workload_size"])
+fn compute(inst: Instance)
+    -> reads(CryptoParams, EncryptedName),
+       writes(EncryptedResult)
+{
+    let params = load(CryptoParams, from: keydir(inst))
+    let eqry = load(EncryptedName, from: encdir(inst)).positions
+
+    // Server's private dataset, column-major packing prepared by the
+    // harness: (n_batches * n_slots) rows x name_len cols, zero-padded.
+    let dataset = load_matrix<f64>(dataset_file(inst), inst.name_len)
+    let n_batches = rows(dataset) / inst.n_slots
+
+    let acc_total: enc<vec<f64>> = zero()
+
+    for b in 0..n_batches {
+        // Squared Euclidean distance per slot
+        let acc: enc<vec<f64>> = zero()
+        for pos in 0..inst.name_len {
+            let column = dataset[b*inst.n_slots .. (b+1)*inst.n_slots, pos]
+            let diff = eqry[pos] - column
+            acc = acc + diff * diff
+        }
+
+        // Normalize to [0,1] and complement: match ~= 1, non-match < 1
+        let ct_t = negate(acc * (1.0 / norm_const(inst))) + 1.0
+
+        // Iterated squaring: non-matches decay exponentially toward 0
+        for r in 0..inst.k_squarings {
+            ct_t = ct_t * ct_t
+        }
+
+        // Aggregate this batch's indicators across all SIMD slots
+        let ct_batch = ct_t |> slot_sum(inst.n_slots)
+        acc_total = acc_total + ct_batch
+    }
+
+    return EncryptedResult { score: acc_total }
+}

--- a/dsl_fhe/examples/set-membership/shared.nb
+++ b/dsl_fhe/examples/set-membership/shared.nb
@@ -1,0 +1,100 @@
+// shared.nb — Types and constants for private set-membership (name matching)
+//============================================================================
+// Privacy-preserving name matching: given a client's private name and a
+// server's private dataset of names, determine whether the name appears in
+// the dataset — without revealing the query to the server or the dataset
+// to the client.
+//
+// Names are encoded OUTSIDE the FHE circuit (harness/encode_names.py) as
+// fixed-length integer vectors (letters a-z -> 1..26, zero padding), either
+// raw (Exact mode, L=20 characters) or Soundex-hashed (fuzzy mode, L=4).
+//
+// CKKS comparison circuit (per SIMD slot j = one dataset name):
+//   1. diff_i = query[i] - dataset[j][i]      per character position
+//   2. S_j    = sum_i diff_i^2                squared distance      [1 level]
+//   3. s_j    = S_j / C                       normalize to [0,1]    [1 level]
+//   4. t_j    = 1 - s_j                       match ~= 1, non-match < 1
+//   5. t_j    = t_j ^ (2^K)                   iterated squaring     [K levels]
+//   6. score  = sum_j t_j                     aggregate across slots
+//
+// The client decrypts score: each matching name contributes ~1.0, each
+// non-match decays to ~0, so score > 0.5 means "at least one match".
+//
+// K is chosen so the worst non-match indicator (1 - 1/C)^(2^K) < 0.01,
+// with C = 26^2 * L the largest possible squared distance.
+// Total multiplicative depth: 2 + K.
+//============================================================================
+
+// ============================================================================
+// Instance profiles
+// ============================================================================
+
+enum Profile { Exact, Soundex, ExactFull }
+
+struct Instance {
+    profile: Profile,
+    ring_dim: u32,
+    n_slots: u32,       // CKKS SIMD slots = ring_dim / 2 (names per batch)
+    name_len: u32,      // L: encoded characters per name
+    k_squarings: u32,   // K: iterated-squaring rounds
+    depth: u32,         // multiplicative depth budget: 2 + K
+}
+
+fn instance(profile: Profile) -> Instance {
+    match profile {
+        Exact     => Instance { profile, ring_dim: 2048,  n_slots: 1024,
+                                name_len: 20, k_squarings: 16, depth: 18 },
+        Soundex   => Instance { profile, ring_dim: 2048,  n_slots: 1024,
+                                name_len: 4,  k_squarings: 14, depth: 16 },
+        ExactFull => Instance { profile, ring_dim: 65536, n_slots: 32768,
+                                name_len: 20, k_squarings: 16, depth: 18 },
+    }
+}
+
+fn instance_name(profile: Profile) -> string {
+    match profile {
+        Exact     => "exact",
+        Soundex   => "soundex",
+        ExactFull => "exact_full",
+    }
+}
+
+// C: the largest possible squared distance between two encoded names
+// (every position maximally different: 26^2 per position, L positions).
+fn norm_const(inst: Instance) -> f64 {
+    676.0 * inst.name_len
+}
+
+// ============================================================================
+// Directory layout
+// ============================================================================
+
+fn iodir(inst: Instance) -> path  { root() / "io" / instance_name(inst.profile) }
+fn keydir(inst: Instance) -> path { iodir(inst) / "keys" }
+fn encdir(inst: Instance) -> path { iodir(inst) / "encrypted" }
+
+// Written by harness/encode_names.py:
+//   dataset.bin — server's private names, row-major (padded_rows x name_len
+//                 doubles); rows zero-padded to a multiple of n_slots
+//   query.bin   — client's encoded query, replicated (n_slots x name_len)
+fn dataset_file(inst: Instance) -> path { iodir(inst) / "dataset.bin" }
+fn query_file(inst: Instance) -> path   { iodir(inst) / "query.bin" }
+
+// ============================================================================
+// Wire types
+// ============================================================================
+
+wire CryptoParams {
+    context: CryptoContext,
+    public_key: PublicKey,
+    eval_mult_key: EvalMultKey,
+}
+
+wire EncryptedName {
+    positions: vec<enc<vec<f64>>>,   // one ciphertext per character position,
+                                     // the query char replicated in all slots
+}
+
+wire EncryptedResult {
+    score: enc<vec<f64>>,            // slot 0 holds the aggregate match score
+}

--- a/dsl_fhe/xcomp/codegen.py
+++ b/dsl_fhe/xcomp/codegen.py
@@ -2230,6 +2230,12 @@ endforeach()
                     return f"NullSafeEvalAdd(cc, {l}, {r})"
                 return f"cc->EvalAdd({l}, {r})"
             if expr.op == "-":
+                # OpenFHE's EvalSub(ct, Plaintext&) takes a NON-const lvalue
+                # reference; a freshly wrapped MakeCKKSPackedPlaintext rvalue
+                # can't bind. Materialize the plaintext in an IIFE local.
+                if r != right and not right_enc:
+                    return (f"[&]() {{ auto _pt = {r}; "
+                            f"return cc->{FHE_SUB}({l}, _pt); }}()")
                 return f"cc->{FHE_SUB}({l}, {r})"
             if expr.op == "*":
                 return f"cc->{FHE_MUL}({l}, {r})"
@@ -3289,6 +3295,11 @@ endforeach()
             return None
         if isinstance(expr, ast.CastExpr) and expr.target_type:
             return self._type_to_cpp(expr.target_type)
+        # 2D column slice matrix[a..b, c] generates an IIFE returning a
+        # std::vector — record it so a let-bound column participates in
+        # ciphertext-vs-plaintext-vector operator wrapping.
+        if isinstance(expr, ast.IndexExpr) and isinstance(expr.obj, ast.SliceExpr):
+            return "std::vector<double>"
         if isinstance(expr, ast.CallExpr) and isinstance(expr.func, ast.Ident):
             if expr.func.name in self.VECTOR_RETURN_FNS:
                 return "std::vector<double>"

--- a/dsl_fhe/xcomp/tests/test_codegen.py
+++ b/dsl_fhe/xcomp/tests/test_codegen.py
@@ -220,6 +220,23 @@ def test_encrypted_var_heuristic():
     assert enc("recon_loss")     # matches "recon"
 
 
+def test_ct_minus_column_slice():
+    # ct - <2D column slice> must wrap the vector in MakeCKKSPackedPlaintext
+    # AND materialize it as an lvalue (OpenFHE's EvalSub takes Plaintext&,
+    # which can't bind a freshly-created rvalue).
+    files = compile_str("""
+    fn f(eqry: vec<enc<vec<f64>>>, dataset: mat<f64>, n: u32) -> enc<vec<f64>> {
+        let column = dataset[0..n, 0]
+        let diff = eqry[0] - column
+        return diff * diff
+    }
+    """)
+    impl = files["nb_shared.cpp"]
+    assert "MakeCKKSPackedPlaintext(column)" in impl
+    assert "auto _pt = " in impl          # lvalue materialization for EvalSub
+    assert "EvalSub(eqry[0], _pt)" in impl
+
+
 def test_shared_fn_forward_decl():
     files = compile_str("""
     fn helper(x: f64) -> f64 {


### PR DESCRIPTION
## Summary

Ports the `openfhe-set-membership` workload (privacy-preserving name matching) as a new DSL example: given a client's **private name** and a server's **private dataset** of names, determine whether the name appears in the dataset — without revealing the query to the server or the dataset to the client.

## How it works

Names are encoded outside the circuit (`harness/encode_names.py`: letters → 1..26, zero-padded; **Exact** mode L=20 or **Soundex** phonetic hash L=4 for fuzzy matching). The CKKS circuit packs one dataset name per SIMD slot:

1. squared Euclidean distance to the query per character position — 1 level
2. normalize + complement: `t = 1 − S/C`, C = 26²·L — 1 level
3. **iterated squaring** `t^(2^K)`: matches stay ≈1, non-matches decay to ≈0 — K levels
4. slot-sum → aggregate score ≈ number of matches; client thresholds at 0.5

Depth = 2 + K (Exact K=16, Soundex K=14), set per-instance at runtime via `scheme.override(depth: inst.depth)`. The dataset stays plaintext on the server, folded into the circuit column-major as `ct − plaintext_vector`.

## Codegen changes (unit-tested)

- Infer `std::vector<double>` for 2D column-slice locals (`m[a..b, c]`) so `ct ∘ column` wraps the vector in `MakeCKKSPackedPlaintext`.
- OpenFHE's `EvalSub(ct, Plaintext&)` takes a **non-const lvalue ref**; a wrapped plaintext in a subtraction is now materialized in an IIFE local (the original C++ implementation notes this same quirk).

## Verification

`make test-set-membership` runs three cases end-to-end through record/replay:

| Case | Query | Expected | Decrypted |
|---|---|---|---|
| exact match | "James Smith" | 1 | 1.000 |
| no match | "Zelda Quixote" | 0 | 7.3e-15 |
| Soundex fuzzy | "Robbrt Johnson" | 10 (all "Robert *" collide) | 10.021 |

Wired into `examples` / `test-examples` / `test-compiler` / `clean` and the CI DSL step. Full suite (19/19 codegen tests + all six examples) passes. Only source files committed (4 example files + harness); generated C++/binaries/io are git-ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)