### PR TITLE
vendor: bump niobium-fhetch (replay zero fix) + gate fetch replay run in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,9 +182,11 @@ jobs:
           make -C dsl_fhe test-compiler
           make -C dsl_fhe test-simple test-password test-set-membership test-ml test-nid
 
-      # fetch-by-similarity end-to-end (record run): generates the dataset,
-      # records the trace, and verifies all 8 payload vectors decrypt correctly.
-      - name: DSL — fetch-by-similarity end-to-end
+      # fetch-by-similarity end-to-end: the record run generates the dataset,
+      # records the trace, and verifies all 8 payload vectors; the replay run
+      # (cache hit, zero FHE ops) re-executes through the FHETCH simulator and
+      # must reproduce the same verified payloads.
+      - name: DSL — fetch-by-similarity end-to-end (record + replay)
         run: |
           python3 -m pip install --user --quiet numpy
           make -C dsl_fhe test-fetch

--- a/dsl_fhe/Makefile
+++ b/dsl_fhe/Makefile
@@ -317,7 +317,14 @@ test-fetch: fetch-by-similarity
 	@cd $(EXAMPLES)/fetch-by-similarity && \
 		export LD_LIBRARY_PATH=$(LD_LIB_PATH) && \
 		rm -rf *_workload_* fhetch_driver_source_* && \
-		python3 harness/run.py 0 --seed 42
+		python3 harness/run.py 0 --seed 42 && \
+		echo "" && \
+		echo "=== Replay run (cache hit — zero FHE ops, FHETCH simulator) ===" && \
+		nb_out/build/encrypted_compute 0 && \
+		nb_out/build/decrypt_decode 0 && \
+		nb_out/build/postprocess 0 && \
+		python3 harness/verify_result.py datasets/toy/expected.bin io/toy/results.bin && \
+		echo "  PASS  replay run verified against expected payloads"
 	@echo ""
 	@echo "All fetch-by-similarity tests passed."
 


### PR DESCRIPTION
Completes review weakness #8.

- **Bump `vendor/niobium-fhetch` → `71c8e72`** ([niobium-fhetch#77](https://github.com/NiobiumInc/niobium-fhetch/pull/77)): removes the legacy zero-init prematerialization that poisoned captured-input propagation on replay (prematerialized addresses blocked real data from the parent chain and spread zeros — the source of "live-in data check (384 all-zero of 9308)" and zero results with 0 sim errors on large traces).
- **`test-fetch` now gates the replay path too**: record run (harness, 8/8 payload vectors) **then** a cache-hit replay run (zero FHE ops, 1.57M-instruction trace through the FHETCH simulator) re-verified against the same expected payloads. CI step renamed to "record + replay".

Verified locally at this rev: record **PASS** + replay **PASS**; in niobium-fhetch, bootstrap and simple_ops roundtrips (primary + driver-replay secondary) all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)