### PR TITLE
dsl_fhe: fraud-flag example — skill eval #4 dogfooded end to end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
           export CC="ccache gcc"
           export CXX="ccache g++"
           make -C dsl_fhe test-compiler
-          make -C dsl_fhe test-simple test-password test-set-membership test-ml test-nid
+          make -C dsl_fhe test-simple test-password test-set-membership test-fraud test-ml test-nid
 
       # fetch-by-similarity end-to-end: the record run generates the dataset,
       # records the trace, and verifies all 8 payload vectors; the replay run

--- a/dsl_fhe/CLAUDE.md
+++ b/dsl_fhe/CLAUDE.md
@@ -438,6 +438,7 @@ dsl_fhe/
       shared.nb, client.nb, server.nb
       nb_out/                        # Generated C++ + build
       README.md                      # Design rationale and usage guide
+    fraud-flag/                      # Private card-number checking (skill dogfood; README = 8-stage walkthrough)
     set-membership/                  # Private name matching (exact + Soundex fuzzy)
       shared.nb, client.nb, server.nb
       harness/encode_names.py        # Plaintext name encoding -> dataset.bin/query.bin

--- a/dsl_fhe/Makefile
+++ b/dsl_fhe/Makefile
@@ -18,7 +18,7 @@ NIOBIUM_CLIENT_ROOT ?= $(realpath $(CURDIR)/..)
 SUBMISSION_REPO ?=
 
 .PHONY: test-compiler examples fetch-by-similarity simple fhe-network-monitor ml-inference \
-       set-membership test-set-membership \
+       set-membership test-set-membership fraud-flag test-fraud \
        password-retrieval test-simple test-fetch test-nid test-ml test-password test-examples \
        clean help
 
@@ -64,6 +64,10 @@ test-compiler:
 	@cd $(XCOMP) && python3 nbc.py parse ../$(EXAMPLES)/set-membership/client.nb  > /dev/null
 	@cd $(XCOMP) && python3 nbc.py parse ../$(EXAMPLES)/set-membership/server.nb  > /dev/null
 	@echo "  PASS  parse set-membership/*.nb"
+	@cd $(XCOMP) && python3 nbc.py parse ../$(EXAMPLES)/fraud-flag/shared.nb  > /dev/null
+	@cd $(XCOMP) && python3 nbc.py parse ../$(EXAMPLES)/fraud-flag/client.nb  > /dev/null
+	@cd $(XCOMP) && python3 nbc.py parse ../$(EXAMPLES)/fraud-flag/server.nb  > /dev/null
+	@echo "  PASS  parse fraud-flag/*.nb"
 	@echo ""
 	@echo "=== End-to-end: semantic check ==="
 	@cd $(XCOMP) && python3 nbc.py check \
@@ -90,6 +94,10 @@ test-compiler:
 		../$(EXAMPLES)/set-membership/shared.nb \
 		../$(EXAMPLES)/set-membership/client.nb \
 		../$(EXAMPLES)/set-membership/server.nb
+	@cd $(XCOMP) && python3 nbc.py check \
+		../$(EXAMPLES)/fraud-flag/shared.nb \
+		../$(EXAMPLES)/fraud-flag/client.nb \
+		../$(EXAMPLES)/fraud-flag/server.nb
 	@echo ""
 	@echo "All tests passed."
 
@@ -102,7 +110,7 @@ test-compiler:
 # but don't produce real results (real model/weights need the submission; see
 # each example's data/README.md). test-examples runs only the examples that
 # produce meaningful, verifiable output.
-examples: simple fetch-by-similarity ml-inference fhe-network-monitor password-retrieval set-membership test-examples
+examples: simple fetch-by-similarity ml-inference fhe-network-monitor password-retrieval set-membership fraud-flag test-examples
 
 # --- fetch-by-similarity ---
 
@@ -254,6 +262,27 @@ set-membership:
 		$(MAKE) -j$(NPROC) 2>&1
 	@echo ""
 	@echo "Built binaries in $(SETM_NB_OUT)/build/"
+
+# --- fraud-flag (private card-number set membership) ---
+
+FRAUD_NB_OUT := $(EXAMPLES)/fraud-flag/nb_out
+
+fraud-flag:
+	@echo "=== Compiling fraud-flag (DSL → C++) ==="
+	@mkdir -p $(FRAUD_NB_OUT)
+	@cd $(XCOMP) && python3 nbc.py compile \
+		../$(EXAMPLES)/fraud-flag/shared.nb \
+		../$(EXAMPLES)/fraud-flag/client.nb \
+		../$(EXAMPLES)/fraud-flag/server.nb \
+		--outdir ../$(FRAUD_NB_OUT)
+	@echo ""
+	@echo "=== Building fraud-flag (C++ → binaries) ==="
+	@mkdir -p $(FRAUD_NB_OUT)/build
+	@cd $(FRAUD_NB_OUT)/build && \
+		cmake .. -DNIOBIUM_CLIENT_ROOT=$(NIOBIUM_CLIENT_ROOT) && \
+		$(MAKE) -j$(NPROC) 2>&1
+	@echo ""
+	@echo "Built binaries in $(FRAUD_NB_OUT)/build/"
 
 password-retrieval:
 	@echo "=== Compiling password-retrieval (DSL → C++) ==="
@@ -411,7 +440,32 @@ test-set-membership: set-membership
 		rm -rf io *_workload_* fhetch_driver_source_* && \
 		echo "" && echo "All set-membership tests passed."
 
-test-examples: test-simple test-fetch test-password test-set-membership
+test-fraud: fraud-flag
+	@echo ""
+	@echo "=== Testing fraud-flag (end-to-end, toy profile, 5000 cards) ==="
+	@cd $(EXAMPLES)/fraud-flag && \
+		export LD_LIBRARY_PATH=$(LD_LIB_PATH) && \
+		rm -rf io *_workload_* fhetch_driver_source_* && \
+		B=nb_out/build && \
+		echo "  flagged card (expect 1)..." && \
+		python3 harness/encode_cards.py 0 --query-flagged 1234 && \
+		$$B/key_generation 0 && $$B/encrypt_card 0 && $$B/check_card 0 && \
+		$$B/decrypt_verify 0 1.0 && \
+		echo "  PASS  flagged card → score ≈ 1" && \
+		echo "  clean card (expect 0)..." && \
+		rm -rf *_workload_* fhetch_driver_source_* && \
+		python3 harness/encode_cards.py 0 --query-card 9999888877776666 && \
+		$$B/encrypt_card 0 && $$B/check_card 0 && \
+		$$B/decrypt_verify 0 0.0 && \
+		echo "  PASS  clean card → score ≈ 0" && \
+		echo "  cleartext reference pipeline (generated ground truth)..." && \
+		$$B/encrypt_card_ref 0 && $$B/check_card_ref 0 && \
+		$$B/decrypt_verify_ref 0 0.0 && \
+		echo "  PASS  reference pipeline agrees" && \
+		rm -rf io *_workload_* fhetch_driver_source_* && \
+		echo "" && echo "All fraud-flag tests passed."
+
+test-examples: test-simple test-fetch test-password test-set-membership test-fraud
 	@echo ""
 	@echo "All example tests passed."
 
@@ -426,6 +480,7 @@ clean:
 		find . -maxdepth 1 -type f ! -name utils.h ! -name .gitignore -delete 2>/dev/null; true
 	rm -rf $(SIMPLE_NB_OUT)
 	rm -rf $(SETM_NB_OUT) $(EXAMPLES)/set-membership/io
+	rm -rf $(FRAUD_NB_OUT) $(EXAMPLES)/fraud-flag/io
 	rm -rf $(NID_NB_OUT)/build
 	cd $(NID_NB_OUT) && \
 		find . -maxdepth 1 -type f ! -name .gitignore -delete 2>/dev/null; true

--- a/dsl_fhe/README.md
+++ b/dsl_fhe/README.md
@@ -163,6 +163,10 @@ dsl_fhe/
       server.nb                        # Squared-distance + iterated-squaring indicator
       harness/encode_names.py          # Plaintext name encoding (exact + Soundex)
       nb_out/                          # Generated C++ + build
+    fraud-flag/                        # Private card-number checking (skill-eval dogfood)
+      shared.nb, client.nb, server.nb  # 8-stage design walkthrough in README.md
+      harness/encode_cards.py          # Plaintext ground truth (5,000-card list)
+      nb_out/                          # Generated C++ + build
     simple/                            # Basic cipher operations (compilable, runnable)
       shared.nb                        # Operation enum (25 ops), instance sizes
       client.nb                        # Encrypt two scalars, decrypt+verify
@@ -202,12 +206,14 @@ make fhe-network-monitor    # Build KitNET anomaly detection (4 binaries)
 make ml-inference           # Build ML inference (4 binaries)
 make password-retrieval     # Build password retrieval (5 binaries)
 make set-membership         # Build private name matching (4 binaries)
+make fraud-flag             # Build private card-number checking (4 + ref binaries)
 make test-simple            # End-to-end: 8 FHE operations verified
 make test-fetch             # End-to-end: toy fetch pipeline
 make test-nid               # End-to-end: toy KitNET (keygen+encrypt+inference)
 make test-ml                # End-to-end: keygen+encrypt+compute (single)
 make test-password          # End-to-end: correct + wrong answer verification
 make test-set-membership    # End-to-end: exact match, no-match, Soundex fuzzy
+make test-fraud             # End-to-end: flagged/clean card + reference pipeline
 make test-examples          # Run all end-to-end tests
 ```
 

--- a/dsl_fhe/examples/fraud-flag/README.md
+++ b/dsl_fhe/examples/fraud-flag/README.md
@@ -1,0 +1,107 @@
+# Fraud-Flag Checking — Private Set Membership for Card Numbers
+
+A client holds a private 16-digit card number; a server holds a private list
+of ~5,000 flagged card numbers. The client learns whether their card is
+flagged — without revealing the number to the server, and without the server
+revealing anything else about its list.
+
+This example was produced by following the **fhe-application-design skill**
+end to end (Stages 1–8) and implementing via **Stage 7 Track A** (the nb
+DSL). The full design rationale is recorded here as the Stage 8 protocol
+specification.
+
+## Stage 1 — Privacy model
+
+| Question | Answer |
+|---|---|
+| Parties | Client (cardholder, holds the PAN); server (holds the flagged list) |
+| Adversary | Semi-honest server: must not learn the queried PAN. Client must not learn the list beyond the one flag bit |
+| Who encrypts | **Single encryptor** — the client encrypts only its own query. The server's list never leaves the server and stays plaintext there (folded into the circuit), so no cross-owner packing question arises |
+| Who decrypts | The client — and the client is also the consumer of the result, so there is **no output-integrity problem** (no transciphering needed) |
+| Output privacy | One bit per query. Repeated adaptive queries could probe the list; deploy behind query rate limiting |
+
+## Stage 2 — Feasibility
+
+Data-oblivious (a fixed arithmetic circuit touches every list entry every
+time — which is also what hides the list), purely arithmetic lane, shallow
+multiplication chain (2 + K), and natural SIMD parallelism (one flagged card
+per slot). A clean fit.
+
+## Stage 3 — Plaintext ground truth
+
+`harness/encode_cards.py` is the plaintext implementation and test-data
+generator: a deterministic (seeded) flagged list of 5,000 cards, digit
+encoding, and the cleartext expected match count that `decrypt_verify`
+asserts against.
+
+## Stage 4 — Scheme
+
+CKKS: the comparison is approximate by design (squared distance + iterated
+squaring with a 0.5 decision threshold), so approximate arithmetic costs
+nothing and buys the fastest bulk numeric throughput.
+
+## Stage 5 — Circuit
+
+- **Encoding**: each digit `d → d+1` (values 1..10), so the zero rows that
+  pad the final batch can never match a real query.
+- **Packing**: column-major — one ciphertext per digit position (L = 16),
+  one flagged card per SIMD slot; 5,000 cards → 5 batches at 1,024 slots
+  (Toy) or 1 batch at 16,384 slots (Full).
+- **Comparison**: per slot, `S = Σ (q_i − c_i)²`; normalize `t = 1 − S/C`
+  with `C = 9²·16 = 1296`; amplify with K iterated squarings; `slot_sum`
+  aggregates. A flagged match contributes ≈ 1, everything else decays to ≈ 0.
+- **K**: `(1 − 1/C)^(2^K) < 0.01` ⇒ `2^K > 1296·ln 100 ≈ 5969` ⇒ **K = 13**,
+  total depth **2 + 13 = 15**.
+
+## Stage 6 — Parameters
+
+`logQ ≈ first_mod + depth × q_i = 60 + 15×50 = 810 bits` → 128-classic fits
+at **ring_dim 32768** (one size smaller than the set-membership example,
+because the shorter L=16 vectors shrink C and therefore K). The compiler's
+params note confirms this exact computation at `nbc check` time:
+
+```
+note: params: logQ ~= 810 bits (first_mod 60 + depth 15 x q_i 50);
+128-classic needs ring_dim >= 32768; declared ring_dims OK: [32768];
+below target: [2048] (covered by scheme.override(security: not_set) dev profiles)
+```
+
+## Stage 7 — Implementation (Track A)
+
+Three `.nb` files (`shared.nb`, `client.nb`, `server.nb`) plus the harness.
+The compiler generates the four-program pipeline, all serialization, matched
+keygen, the Niobium record/replay instrumentation, and **cleartext reference
+twins** (`*_ref` binaries) of every stage.
+
+```bash
+cd dsl_fhe && make test-fraud
+# flagged card  -> score 1.000 (expect 1)
+# clean card    -> score ~ -2e-13 (expect 0; the reference twin computes
+#                  3e-81 — the difference between them IS the CKKS noise)
+# reference pipeline re-verified as generated ground truth
+```
+
+## Stage 8 — Protocol and threat model
+
+1. **Setup (once)**: client runs `key_generation`, sends `cc/pk/mk/rk` to
+   the server. The secret key never leaves the client.
+2. **Per query**: client runs `encrypt_card` (16 ciphertexts) → server runs
+   `check_card` (no secret key linked; the flagged list read from local
+   disk) → client runs `decrypt_verify` and thresholds at 0.5.
+3. **What each party learns**: server sees only ciphertexts and learns
+   nothing about the PAN (semantic security). Client learns one bit
+   (plus the approximate match count if multiple entries collided — card
+   numbers are unique, so this is exactly the flag).
+4. **Incidental leakage**: the batch count reveals the list size to within
+   `n_slots`; computation time is data-independent (oblivious circuit).
+5. **Not addressed**: malicious server (could compute a different function),
+   adaptive query enumeration (rate-limit upstream), traffic analysis.
+
+## Files
+
+| File | Role |
+|---|---|
+| `shared.nb` | Instance profiles, directory layout, wire types |
+| `client.nb` | scheme + keygen, per-digit encryption, decrypt + verify |
+| `server.nb` | `@hardware` squared-distance + iterated-squaring circuit |
+| `harness/encode_cards.py` | Plaintext ground truth: list generation, encoding, expected count |

--- a/dsl_fhe/examples/fraud-flag/client.nb
+++ b/dsl_fhe/examples/fraud-flag/client.nb
@@ -1,0 +1,93 @@
+// client.nb — Client-side stages for private fraud-flag checking
+//============================================================================
+// Runs on the CLIENT machine (owns the secret key).
+// Compiles to:
+//   key_generation  <profile>
+//   encrypt_card    <profile>
+//   decrypt_verify  <profile> [expected_score]
+//
+// Profiles: 0=Toy (ring 2048, dev security), 1=Full (ring 32768, 128-classic)
+//============================================================================
+
+use shared::*
+
+// CKKS, depth = 2 + K (distance squaring + normalization + K iterated
+// squarings). logQ ~= 60 + 15*50 = 810 bits -> 128-classic at ring 32768.
+scheme CKKS {
+    security: 128-classic    // Toy overrides to not_set below
+    key_dist: uniform_ternary
+    scaling: flexible_auto
+    precision: 50
+    first_mod: 60
+    depth: 15
+}
+
+requires { add, mul }
+
+// ============================================================================
+// Stage 1: Key generation
+// ============================================================================
+
+@client @stage("key_generation")
+fn generate_keys(inst: Instance) -> writes(CryptoParams)
+{
+    scheme.override(depth: inst.depth)
+
+    if inst.profile == Toy {
+        scheme.override(security: not_set)    // small ring for fast dev runs
+    }
+
+    let keys = keygen()
+    save_secret_key(keys.secret, keydir(inst) / "sk.bin")
+
+    return CryptoParams {
+        context: keys.context,
+        public_key: keys.public,
+        eval_mult_key: keys.eval_mult,
+    }
+}
+
+// ============================================================================
+// Stage 2: Encrypt the query card
+//
+// query.bin holds the encoded card replicated to n_slots rows (one column
+// per digit position), so each column encrypts to a ciphertext with that
+// position's digit value in every SIMD slot.
+// ============================================================================
+
+@client @stage("encrypt_card")
+fn encrypt_card(inst: Instance) -> reads(CryptoParams), writes(EncryptedCard)
+{
+    let params = load(CryptoParams, from: keydir(inst))
+    let qmat = load_matrix<f64>(query_file(inst), inst.n_digits)
+
+    return EncryptedCard {
+        digits: for pos in 0..inst.n_digits {
+            let column = qmat[0..inst.n_slots, pos]
+            encrypt(params.public_key, column)
+        }
+    }
+}
+
+// ============================================================================
+// Stage 3: Decrypt and verify the flag score
+//
+// A flagged card contributes ~1.0; every other entry decays to ~0 after
+// iterated squaring. expected is the cleartext match count computed by
+// harness/encode_cards.py (0.0 or 1.0 — card numbers are unique).
+// ============================================================================
+
+@client @stage("decrypt_verify")
+fn decrypt_verify(inst: Instance, expected: f64 = 1.0) -> reads(EncryptedResult)
+{
+    let sk = load_secret_key(keydir(inst) / "sk.bin")
+    let encrypted = load(EncryptedResult, from: encdir(inst))
+
+    let result = decrypt(sk, encrypted.flag)
+    let value = result[0]
+
+    print(value)
+
+    let tolerance = 0.3
+    assert abs(value - expected) < tolerance
+}

--- a/dsl_fhe/examples/fraud-flag/harness/encode_cards.py
+++ b/dsl_fhe/examples/fraud-flag/harness/encode_cards.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# Copyright 2024-present Niobium Microsystems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Plaintext side of the fraud-flag example (skill Stage 3: ground truth).
+
+Generates a deterministic flagged-card list, encodes cards as fixed-length
+digit vectors, writes the binary matrices the DSL stages load, and computes
+the cleartext expected match count the decrypt stage verifies against.
+
+Encoding: each of the 16 digits d -> d+1 (values 1..10), so the zero rows
+used to pad the last batch can never match a real query.
+
+  io/<profile>/flagged.bin — row-major float64 (padded_rows x 16); the
+      server's private list, rows zero-padded to a multiple of n_slots
+  io/<profile>/query.bin   — float64 (n_slots x 16): the encoded query card
+      replicated down each column
+
+Usage:
+  encode_cards.py PROFILE (--query-flagged INDEX | --query-card DIGITS)
+    PROFILE: 0=Toy (1,024 slots)  1=Full (16,384 slots)
+    --query-flagged N  query the N-th card OF the flagged list (expect 1)
+    --query-card D...  query an explicit 16-digit card (expect 0 or 1)
+"""
+import argparse
+import random
+import struct
+import sys
+from pathlib import Path
+
+PROFILES = {0: ("toy", 1024), 1: ("full", 16384)}
+N_DIGITS = 16
+N_FLAGGED = 5000
+SEED = 42
+
+EXAMPLE_ROOT = Path(__file__).resolve().parent.parent
+
+
+def gen_flagged() -> list[str]:
+    rng = random.Random(SEED)
+    cards = set()
+    while len(cards) < N_FLAGGED:
+        cards.add("".join(rng.choice("0123456789") for _ in range(N_DIGITS)))
+    return sorted(cards)
+
+
+def encode(card: str) -> list[float]:
+    return [float(int(c) + 1) for c in card]
+
+
+def write_doubles(path: Path, rows: list[list[float]]):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "wb") as f:
+        for r in rows:
+            f.write(struct.pack(f"<{len(r)}d", *r))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("profile", type=int, choices=sorted(PROFILES))
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--query-flagged", type=int,
+                   help="query the N-th flagged card (expect 1)")
+    g.add_argument("--query-card",
+                   help="explicit 16-digit card number")
+    args = ap.parse_args()
+
+    pname, n_slots = PROFILES[args.profile]
+    iodir = EXAMPLE_ROOT / "io" / pname
+
+    flagged = gen_flagged()
+    if args.query_flagged is not None:
+        query = flagged[args.query_flagged % len(flagged)]
+    else:
+        query = args.query_card
+        if len(query) != N_DIGITS or not query.isdigit():
+            sys.exit(f"--query-card must be {N_DIGITS} digits")
+
+    enc_flagged = [encode(c) for c in flagged]
+    enc_query = encode(query)
+
+    padded = -(-len(enc_flagged) // n_slots) * n_slots
+    rows = enc_flagged + [[0.0] * N_DIGITS] * (padded - len(enc_flagged))
+    write_doubles(iodir / "flagged.bin", rows)
+    write_doubles(iodir / "query.bin", [enc_query] * n_slots)
+
+    expected = sum(1 for e in enc_flagged if e == enc_query)
+    print(f"encoded {len(flagged)} flagged cards "
+          f"({padded} padded rows, {padded // n_slots} batches) -> {iodir}")
+    print(f"query {query} expected matches: {expected}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dsl_fhe/examples/fraud-flag/server.nb
+++ b/dsl_fhe/examples/fraud-flag/server.nb
@@ -1,0 +1,62 @@
+// server.nb — Server-side encrypted fraud-flag evaluation
+//============================================================================
+// Runs on the SERVER machine. NO access to the secret key. The flagged-card
+// list is the server's PRIVATE data — loaded as a plaintext matrix here and
+// folded into the homomorphic circuit; it never leaves the server, and the
+// client's card number is never decrypted.
+// Compiles to:
+//   check_card <profile>
+//============================================================================
+
+use shared::*
+
+// ============================================================================
+// Encrypted evaluation: squared distance + iterated-squaring indicator
+//
+// For each batch of n_slots flagged cards (one card per SIMD slot):
+//   acc   = sum_pos (query[pos] - flagged_column[pos])^2      [1 level]
+//   ct_t  = 1 - acc/C                                          [1 level]
+//   ct_t  = ct_t^(2^K)     (K squarings amplify the gap)       [K levels]
+//   flag += slot_sum(ct_t) (the flagged card contributes ~1)
+// ============================================================================
+
+@server @stage("check_card")
+@hardware(cache_key: ["workload_size"])
+fn check_card(inst: Instance)
+    -> reads(CryptoParams, EncryptedCard),
+       writes(EncryptedResult)
+{
+    let params = load(CryptoParams, from: keydir(inst))
+    let eqry = load(EncryptedCard, from: encdir(inst)).digits
+
+    // Server's private flagged list, column-major packing prepared by the
+    // harness: (n_batches * n_slots) rows x n_digits cols, zero-padded.
+    let flagged = load_matrix<f64>(flagged_file(inst), inst.n_digits)
+    let n_batches = rows(flagged) / inst.n_slots
+
+    let acc_total: enc<vec<f64>> = zero()
+
+    for b in 0..n_batches {
+        // Squared Euclidean distance to the query, per slot
+        let acc: enc<vec<f64>> = zero()
+        for pos in 0..inst.n_digits {
+            let column = flagged[b*inst.n_slots .. (b+1)*inst.n_slots, pos]
+            let diff = eqry[pos] - column
+            acc = acc + diff * diff
+        }
+
+        // Normalize to [0,1] and complement: flagged ~= 1, others < 1
+        let ct_t = negate(acc * (1.0 / norm_const(inst))) + 1.0
+
+        // Iterated squaring: non-matches decay exponentially toward 0
+        for r in 0..inst.k_squarings {
+            ct_t = ct_t * ct_t
+        }
+
+        // Aggregate this batch's indicators across all SIMD slots
+        let ct_batch = ct_t |> slot_sum(inst.n_slots)
+        acc_total = acc_total + ct_batch
+    }
+
+    return EncryptedResult { flag: acc_total }
+}

--- a/dsl_fhe/examples/fraud-flag/shared.nb
+++ b/dsl_fhe/examples/fraud-flag/shared.nb
@@ -1,0 +1,88 @@
+// shared.nb — Types and constants for private fraud-flag checking
+//============================================================================
+// A client holds a private 16-digit card number; a server holds a private
+// list of ~5,000 flagged card numbers. The client learns whether their card
+// is flagged — without revealing the number to the server, and without the
+// server revealing anything else about its list.
+//
+// Design (skill stages 1–6; full walkthrough in README.md):
+//   - Single encryptor: the client encrypts the query card; the server's
+//     list stays plaintext on the server and is folded into the circuit.
+//   - Encoding (harness/encode_cards.py): each digit d -> d+1 (values 1..10),
+//     so zero-padded batch rows can never match a real query.
+//   - Column-major SIMD: one ciphertext per digit position (L=16), one
+//     flagged card per slot; 5,000 cards -> 5 batches at 1,024 slots (Toy).
+//   - Circuit per slot: S = sum_i (q_i - c_i)^2; t = 1 - S/C with
+//     C = 9^2 * 16 = 1296; t^(2^K) amplifies (match ~= 1, others -> 0);
+//     slot_sum aggregates. K: (1 - 1/C)^(2^K) < 0.01 -> K = 13 -> depth 15.
+//   - Parameters: logQ ~= 60 + 15*50 = 810 bits -> 128-classic fits at
+//     ring_dim 32768 (the compiler's params note confirms).
+//============================================================================
+
+enum Profile { Toy, Full }
+
+struct Instance {
+    profile: Profile,
+    ring_dim: u32,
+    n_slots: u32,       // flagged cards per batch (ring_dim / 2)
+    n_digits: u32,      // L = 16 (fixed-length card numbers, no padding)
+    k_squarings: u32,   // K = 13
+    depth: u32,         // 2 + K = 15
+}
+
+fn instance(profile: Profile) -> Instance {
+    match profile {
+        Toy  => Instance { profile, ring_dim: 2048,  n_slots: 1024,
+                           n_digits: 16, k_squarings: 13, depth: 15 },
+        Full => Instance { profile, ring_dim: 32768, n_slots: 16384,
+                           n_digits: 16, k_squarings: 13, depth: 15 },
+    }
+}
+
+fn instance_name(profile: Profile) -> string {
+    match profile {
+        Toy  => "toy",
+        Full => "full",
+    }
+}
+
+// C: the largest possible squared distance between two encoded cards
+// (digit values 1..10 -> max per-position diff 9; 16 positions).
+fn norm_const(inst: Instance) -> f64 {
+    81.0 * inst.n_digits
+}
+
+// ============================================================================
+// Directory layout
+// ============================================================================
+
+fn iodir(inst: Instance) -> path  { root() / "io" / instance_name(inst.profile) }
+fn keydir(inst: Instance) -> path { iodir(inst) / "keys" }
+fn encdir(inst: Instance) -> path { iodir(inst) / "encrypted" }
+
+// Written by harness/encode_cards.py:
+//   flagged.bin — server's private flagged list, row-major
+//                 (padded_rows x n_digits doubles), zero-padded to a
+//                 multiple of n_slots
+//   query.bin   — client's encoded card, replicated (n_slots x n_digits)
+fn flagged_file(inst: Instance) -> path { iodir(inst) / "flagged.bin" }
+fn query_file(inst: Instance) -> path   { iodir(inst) / "query.bin" }
+
+// ============================================================================
+// Wire types (field-type-driven serialization; names are domain-chosen)
+// ============================================================================
+
+wire CryptoParams {
+    context: CryptoContext,
+    public_key: PublicKey,
+    eval_mult_key: EvalMultKey,
+}
+
+wire EncryptedCard {
+    digits: vec<enc<vec<f64>>>,      // one ciphertext per digit position,
+                                     // the digit value replicated in all slots
+}
+
+wire EncryptedResult {
+    flag: enc<vec<f64>>,             // slot 0: aggregate match score
+}


### PR DESCRIPTION
Roadmap item 1: execute the skill's **eval #4** as a fresh user — design the private fraud-flag checker (client's 16-digit card vs server's 5,000-card flagged list) through the skill's 8 stages, implement via **Track A**, and record the walkthrough as the example's README (the Stage 8 artifact).

## Design (Stages 1–6, condensed)

Single encryptor (client query; server list stays plaintext server-side, no transciphering since decryptor = consumer); column-major packing (one ct per digit, L=16, digits encoded 1..10 so batch padding can't match); squared distance + **K=13** iterated squarings (C = 9²·16 = 1296); **depth 15** → logQ ≈ 810 → **128-classic at N=32768** — one ring size smaller than set-membership because shorter vectors shrink C and hence K.

## Dogfood verdict: zero friction

- First `nbc check`: **0 warnings / 0 errors**, and the params note independently reproduced the Stage 6 math (`logQ ~= 810 bits; 128-classic needs ring_dim >= 32768; declared OK: [32768]`).
- First build: clean, 7 binaries including generated reference twins.
- First run: flagged → **1.000**, clean → **−2.2e-13**, reference twin → **3.1e-81** (the encrypted-vs-reference gap *is* the CKKS noise, cleanly bounded by the generated ground truth).
- No heuristic warnings, no wire-name workarounds, no codegen surprises — the naming/layout/typing/advisor work from this cycle held up under fresh use.

`make test-fraud` (flagged + clean + reference pipelines over 5 batches) is wired into the aggregates and CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)