### PR TITLE
dsl_fhe: @encryptors(independent) — compiler-checked encryption model

### DIFF
--- a/dsl_fhe/CLAUDE.md
+++ b/dsl_fhe/CLAUDE.md
@@ -52,7 +52,9 @@ spends ~80% of its code on plumbing:
 ## Core Design Principles
 
 1. **Trust boundaries are language constructs.** `@client` / `@server` compile to
-   separate binaries. The compiler rejects server code that references `SecretKey`.
+   separate binaries. The compiler rejects server code that references `SecretKey`,
+   and `@encryptors(independent)` stages reject cross-owner SIMD packing
+   (encrypting a column slice that spans records).
 
 2. **Declare intent, not mechanism.** `requires { add, mul, rotate }` replaces manual
    key generation. `@hardware(cache_key: [...])` replaces 120 lines of record/replay.

--- a/dsl_fhe/GRAMMAR.md
+++ b/dsl_fhe/GRAMMAR.md
@@ -471,6 +471,11 @@ RULE hardware-instrumentation:
 RULE hardware-domain:
   @hardware may only appear on @server functions.
   It is a compile error to annotate a @client function with @hardware.
+
+  A function annotated with @encryptors(independent) declares the
+  independent-encryptor model: encrypt() of a column slice spanning records
+  (m[a..b, col]) is a compile error (cross-owner SIMD packing). The default,
+  @encryptors(single) or no annotation, permits column-major packing.
 ```
 
 ---

--- a/dsl_fhe/NB_LANGUAGE.md
+++ b/dsl_fhe/NB_LANGUAGE.md
@@ -260,6 +260,29 @@ eval keys, and the crypto context are tagged automatically by the
 instrumented-OpenFHE deserialize hooks (cooperative auto-tagging) — no explicit
 `tag_input`/`tag_keys` calls are emitted.
 
+### `@encryptors(independent)`
+
+Declares the stage's encryption model (skill Stage 1, question 2). Default is
+single-encryptor: one party owns all the data and may pack records across
+SIMD slots (column-major). Annotating a stage `@encryptors(independent)`
+declares that each data owner encrypts independently — and the compiler then
+**rejects cross-owner packing**: `encrypt()` of a column slice spanning
+records (`m[a..b, col]`) is a compile error, because slots from different
+owners in one ciphertext would let one owner's key decrypt another's data.
+Per-record vectors (`m[i]`, explicit vectors) remain fine; SIMD slots may
+still pack one owner's features.
+
+```nb
+@client @stage("encrypt_ballot")
+@encryptors(independent)
+fn encrypt_ballot(inst: Instance, voter: u32) -> reads(CryptoParams), writes(EncBallot) {
+    let params = load(CryptoParams, from: keydir(inst))
+    let ballots = load_matrix<f64>(ballot_file(inst), inst.n_candidates)
+    return EncBallot { ct: encrypt(params.public_key, ballots[voter]) }  // OK: one owner's row
+    // encrypt(params.public_key, ballots[0..inst.n_slots, 0])  <- compile error
+}
+```
+
 ### Return Specifications
 
 Stage functions use `reads`/`writes` instead of simple return types:

--- a/dsl_fhe/xcomp/semantic.py
+++ b/dsl_fhe/xcomp/semantic.py
@@ -365,6 +365,21 @@ class SemanticAnalyzer:
     def _check_fn(self, fn: ast.FnDecl):
         self.current_fn = fn.name
         self.current_domain = self._fn_domain(fn)
+        # Encryption-model enforcement (skill Stage 1/5): in an
+        # @encryptors(independent) stage, each ciphertext may pack only ONE
+        # owner's record — packing a column slice across records (rows) into
+        # one ciphertext would let one owner's key decrypt another's data.
+        self._encryptors_independent = False
+        self._record_slice_vars: set[str] = set()
+        for ann in fn.annotations:
+            if ann.name == "encryptors":
+                mode = ann.args.get("name") or ann.args.get("mode")
+                if mode == "independent":
+                    self._encryptors_independent = True
+                elif mode != "single":
+                    self.errors.error(SemanticError(
+                        f"@encryptors: unknown mode '{mode}' "
+                        f"(expected independent or single)", fn.loc))
         scope = self.current_scope.child(fn.name)
 
         # Bind parameters
@@ -387,6 +402,10 @@ class SemanticAnalyzer:
     def _check_stmt(self, stmt: ast.Node):
         if isinstance(stmt, ast.LetStmt):
             val_type = self._check_expr(stmt.value) if stmt.value else UNKNOWN
+            if (isinstance(stmt.value, ast.IndexExpr)
+                    and isinstance(stmt.value.obj, ast.SliceExpr)):
+                # m[a..b, col] — a column spanning many records (rows)
+                self._record_slice_vars.add(stmt.name)
             if stmt.tuple_names and len(stmt.tuple_names) > 1:
                 # Destructured binding: let (a, b) = expr — define each name.
                 for n in stmt.tuple_names:
@@ -544,6 +563,22 @@ class SemanticAnalyzer:
                 # subcircuit: OpenFHE's Paterson-Stockmeyer evaluation consumes
                 # ceil(log2(degree+1)) + 1 levels (matches the documented
                 # degree->depth table: 5->4, 13->5, 27->6, 59->7, 119->8, ...).
+                if (expr.func.name == "encrypt"
+                        and getattr(self, "_encryptors_independent", False)):
+                    positional = [a for a in expr.args if not a.name]
+                    data = positional[1].value if len(positional) > 1 else None
+                    crosses = (isinstance(data, ast.IndexExpr)
+                               and isinstance(data.obj, ast.SliceExpr)) or (
+                        isinstance(data, ast.Ident)
+                        and data.name in self._record_slice_vars)
+                    if crosses:
+                        self.errors.error(DomainError(
+                            "cross-owner SIMD packing: this stage is "
+                            "@encryptors(independent) — each ciphertext may "
+                            "pack only one owner's record. Encrypt per-record "
+                            "vectors (matrix rows), not column slices across "
+                            "records; column-major packing is for "
+                            "single-encryptor designs", expr.loc))
                 if expr.func.name == "chebyshev":
                     d = self._resolve_int_arg(expr, "degree")
                     if d is None:

--- a/dsl_fhe/xcomp/tests/test_semantic.py
+++ b/dsl_fhe/xcomp/tests/test_semantic.py
@@ -284,6 +284,64 @@ def test_chebyshev_max_error_selects_degree():
     assert any("not compile-time evaluable" in str(e) for e in sa3.errors.errors), sa3.errors.errors
 
 
+def test_encryptors_independent_forbids_cross_owner_packing():
+    common = """
+    scheme CKKS { security: not_set depth: 5 }
+    struct Instance { ring_dim: u32, n_slots: u32, n_feat: u32 }
+    fn datadir(inst: Instance) -> path { root() / "d" }
+    wire CryptoParams { context: CryptoContext, public_key: PublicKey,
+                        eval_mult_key: EvalMultKey }
+    wire EncRecord { ct: enc<vec<f64>> }
+    """
+    # Column-major packing (slots = records) in an independent-encryptor
+    # stage is the privacy violation the skill warns about -> compile error.
+    sa = check(common + """
+    @client @stage(name: "encrypt_all")
+    @encryptors(independent)
+    fn encrypt_all(inst: Instance) -> reads(CryptoParams), writes(EncRecord) {
+        let params = load(CryptoParams, from: datadir(inst))
+        let m = load_matrix<f64>(datadir(inst) / "all_owners.bin", inst.n_feat)
+        let column = m[0..inst.n_slots, 0]
+        return EncRecord { ct: encrypt(params.public_key, column) }
+    }
+    """)
+    assert any("cross-owner" in str(e) for e in sa.errors.errors), sa.errors.errors
+
+    # Per-record (row) packing is fine in independent mode.
+    sa2 = check(common + """
+    @client @stage(name: "encrypt_one")
+    @encryptors(independent)
+    fn encrypt_one(inst: Instance, owner: u32) -> reads(CryptoParams), writes(EncRecord) {
+        let params = load(CryptoParams, from: datadir(inst))
+        let m = load_matrix<f64>(datadir(inst) / "mine.bin", inst.n_feat)
+        let row = m[owner]
+        return EncRecord { ct: encrypt(params.public_key, row) }
+    }
+    """)
+    assert not any("cross-owner" in str(e) for e in sa2.errors.errors), sa2.errors.errors
+
+    # Without the annotation (single-encryptor default), column-major
+    # packing remains the recommended pattern.
+    sa3 = check(common + """
+    @client @stage(name: "encrypt_db")
+    fn encrypt_db(inst: Instance) -> reads(CryptoParams), writes(EncRecord) {
+        let params = load(CryptoParams, from: datadir(inst))
+        let m = load_matrix<f64>(datadir(inst) / "my_db.bin", inst.n_feat)
+        let column = m[0..inst.n_slots, 0]
+        return EncRecord { ct: encrypt(params.public_key, column) }
+    }
+    """)
+    assert not any("cross-owner" in str(e) for e in sa3.errors.errors), sa3.errors.errors
+
+    # Unknown mode is rejected.
+    sa4 = check(common + """
+    @client @stage(name: "f")
+    @encryptors(sideways)
+    fn f(inst: Instance) -> u32 { return 0 }
+    """)
+    assert any("unknown mode" in str(e) for e in sa4.errors.errors), sa4.errors.errors
+
+
 if __name__ == "__main__":
     tests = [v for k, v in globals().items() if k.startswith("test_")]
     passed = 0


### PR DESCRIPTION
Roadmap item 2 — the last skill rule that was prose-only ("never pack across independent encryptors", Stage 1/5) becomes a compiler check.

## Semantics

- `@encryptors(independent)` on a stage declares the independent-encryptor model. The compiler then **rejects** `encrypt()` of a **column slice spanning records** (`m[a..b, col]`, directly or through a let-bound local) — slots from different owners in one ciphertext would let one owner's key decrypt another's data:
  ```
  error: cross-owner SIMD packing: this stage is @encryptors(independent) — each
  ciphertext may pack only one owner's record. Encrypt per-record vectors (matrix
  rows), not column slices across records; column-major packing is for
  single-encryptor designs
  ```
- Per-record rows (`m[i]`) and explicit vectors remain legal (one owner's features may still use slots).
- Default (no annotation / `single`): unchanged — column-major stays the recommended single-encryptor pattern.
- Unknown modes rejected.

No parser changes (annotations are generic); codegen ignores it. Docs: NB_LANGUAGE (with a voting-ballot example), GRAMMAR, CLAUDE.

## Verification

23/23 semantic tests (violation / per-record-OK / single-unaffected / unknown-mode); all seven examples at 0 warnings, 0 errors.

Companion skill PR updates the "packing legality" mapping row and removes encryption-model enforcement from the "not yet compiler-checked" list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)