### PR TITLE
dsl_fhe: delete the variable-name heuristic — encrypted-ness is fully structural

### DIFF
--- a/dsl_fhe/CLAUDE.md
+++ b/dsl_fhe/CLAUDE.md
@@ -180,11 +180,12 @@ without any `enc<T>` in their signature.
 Built-in FHE operations (`rotate`, `negate`, etc.) use `cc->` directly in their
 codegen handlers and don't need to be in `FHE_SHARED_FNS`.
 
-### Encrypted-Variable Detection: Structural Flow with a Warned Fallback
+### Encrypted-Variable Detection Is Fully Structural
 
 `_is_encrypted_expr()` decides whether an expression is a ciphertext — which
 drives critical codegen choices (`NullSafeEvalAdd` vs `cc->EvalAdd`, whether to
-`const_pointer_cast`, etc.). Classification is **structural first**:
+`const_pointer_cast`, etc.). Classification is **purely structural** — there
+is no name heuristic:
 
 - let-binding flow (`_enc_vars`/`_plain_vars` via `_record_let_enc_state`):
   explicit `enc<T>` annotations, builtin return kinds from the unified
@@ -199,14 +200,12 @@ drives critical codegen choices (`NullSafeEvalAdd` vs `cc->EvalAdd`, whether to
 - destructured tuples from user fns with declared tuple returns record each
   position.
 
-Only when none of that resolves does it fall back to the **name heuristic**
-(`ENCRYPTED_PREFIXES` / `ENCRYPTED_EXACT_NAMES`) — and every fallback is
-reported as a per-variable warning by `nbc compile`
-("encrypted-ness of 'x' ... decided by the variable-name heuristic"). All six
-shipped examples compile with **zero** fallbacks. When you see the warning,
-add an annotation (`let x: enc<...> = ...`) or rename a plaintext variable —
-don't rely on the heuristic for new code. `test_enc_flow_beats_name_heuristic`
-and friends in `tests/test_codegen.py` pin the behavior.
+A name the machinery cannot resolve is **plaintext**: if it was actually a
+ciphertext, the generated C++ fails to compile (vector/scalar ops on a
+`Ciphertext` shared_ptr) — never silently wrong. The fix is always an
+annotation (`let x: enc<vec<f64>> = ...`), never a naming convention. The
+removal was validated by byte-identical generated C++ across all seven
+examples; `test_no_name_heuristic` pins it.
 
 ### How `encrypt()` Compiles
 

--- a/dsl_fhe/xcomp/codegen.py
+++ b/dsl_fhe/xcomp/codegen.py
@@ -80,32 +80,6 @@ OPENFHE_INCLUDES = [
 
 NIOBIUM_INCLUDE = "niobium/compiler.h"
 
-# Names that indicate encrypted ciphertext variables (exact names or safe prefixes)
-# IMPORTANT: Avoid short prefixes that match plaintext constant names
-ENCRYPTED_PREFIXES = (
-    "ct_", "ct",  # ct or ct_something
-    "enc_", "encrypted",
-    "eqry", "edb", "eres",
-    "result",
-    "acc",  # accumulator variable
-    "indicator",
-    "replicated",
-    "masked",
-    "payload_block",  # NOT "payload" — conflicts with PAYLOAD_DIM constant
-    "to_replicate",
-    "accumulator",
-    "matches",
-    "qry_slot",
-    "residual",  # NID: reconstruction residuals (enc vectors)
-    "hidden",    # NID: hidden layer ciphertexts
-    "recon",     # NID: reconstruction layer ciphertexts
-)
-
-# Exact encrypted variable names (not prefix-based)
-ENCRYPTED_EXACT_NAMES = {
-    "ct", "acc", "part", "eqry", "edb",
-    "mse", "diff", "score",  # NID: anomaly detector accumulators
-}
 
 # Functions whose return value is always a ciphertext
 
@@ -161,9 +135,6 @@ class CodeGenerator:
         # Locals holding a loaded wire struct: name -> wire type name, so
         # field accesses (w.field) resolve from the wire declaration.
         self._wire_vars: dict[str, str] = {}
-        # (fn, var) pairs whose encrypted-ness was decided by the NAME
-        # heuristic rather than structural typing — reported as warnings.
-        self.heuristic_fallbacks: set[tuple[str, str]] = set()
         # Plaintext-reference mode: when True, expression/type/IO generation
         # produces the cleartext twin (enc<T> -> std::vector<double> slot
         # vectors, FHE ops -> nb_plain:: elementwise helpers, wire IO ->
@@ -3704,17 +3675,13 @@ endforeach()
                 for p in self._current_fn.params:
                     if p.name == expr.name and self._has_enc_type(p.type_ann):
                         return True
-            # ALL_CAPS names are constants, never encrypted
-            if expr.name.isupper() or expr.name.startswith("PAYLOAD") or expr.name.startswith("MAX_") or expr.name.startswith("RUNNING_") or expr.name.startswith("THRESHOLD"):
-                return False
-            name = expr.name.lower()
-            if name in ENCRYPTED_EXACT_NAMES or name.startswith(ENCRYPTED_PREFIXES):
-                # Classification fell back to the name heuristic — correct for
-                # conventionally-named ciphertexts, but unverified. Surfaced
-                # as a per-variable warning so authors can annotate instead.
-                fn_name = self._current_fn.name if self._current_fn else "?"
-                self.heuristic_fallbacks.add((fn_name, expr.name))
-                return True
+            # Unresolved names are plaintext. Encrypted-ness is fully
+            # structural (annotations, builtin/user-fn return types,
+            # let-binding flow, loop elements, closure params, wire fields,
+            # destructured tuples); a genuinely-encrypted local the flow
+            # cannot reach fails at C++ compile time — annotate it
+            # (let x: enc<...> = ...) rather than relying on its name.
+            return False
         if isinstance(expr, ast.CallExpr) and isinstance(expr.func, ast.Ident):
             call_state = self._call_enc_state(expr.func.name)
             if call_state is not None:
@@ -3723,8 +3690,6 @@ endforeach()
             wf = self._wire_field_enc_state(expr)
             if wf is not None:
                 return wf
-            if expr.field_name in ("query", "result", "data"):
-                return True
         if isinstance(expr, ast.BinaryExpr):
             return (self._is_encrypted_expr(expr.left) or
                     self._is_encrypted_expr(expr.right))
@@ -3842,10 +3807,4 @@ endforeach()
 def generate(program: ast.Program, analyzer: SemanticAnalyzer) -> dict[str, str]:
     """Convenience function to generate all C++ files."""
     gen = CodeGenerator(program, analyzer)
-    files = gen.generate_all()
-    for fn_name, var in sorted(gen.heuristic_fallbacks):
-        analyzer.errors.warn(
-            f"encrypted-ness of '{var}' in '{fn_name}' was decided by the "
-            f"variable-name heuristic; add a type annotation "
-            f"(let {var}: enc<...> = ...) or rename if it is plaintext")
-    return files
+    return gen.generate_all()

--- a/dsl_fhe/xcomp/tests/test_codegen.py
+++ b/dsl_fhe/xcomp/tests/test_codegen.py
@@ -204,20 +204,20 @@ def test_scheme_override_detected_when_nested():
     assert gen._fn_has_scheme_override(fn) is True
 
 
-def test_encrypted_var_heuristic():
-    # The prefix/name heuristic is a *fallback* used only when no type info is
-    # available. Guard the known-good classifications, and pin the known
-    # false-positives so any future type-driven fix is an intentional change.
+def test_no_name_heuristic():
+    # Encrypted-ness is fully structural — variable NAMES carry no meaning.
+    # Names that the old prefix heuristic classified as encrypted (including
+    # its known false positives) are all plaintext when unresolvable, and the
+    # ALL_CAPS rule is gone with it.
     import ast_nodes as ast
     gen, _ = _make_gen(KEYGEN_SRC.format(ring=""))
     enc = lambda n: gen._is_encrypted_expr(ast.Ident(name=n))
-    assert enc("ct") and enc("acc") and enc("result")     # genuinely encrypted
-    assert not enc("THRESHOLD") and not enc("PAYLOAD_DIM")  # ALL_CAPS constants
-    # KNOWN false positives — these are plaintext but match an encrypted prefix.
-    # See CLAUDE.md "prefix-based encrypted detection". Update if types replace it.
-    assert enc("result_index")   # matches "result"
-    assert enc("hidden_dim")     # matches "hidden"
-    assert enc("recon_loss")     # matches "recon"
+    for name in ("ct", "acc", "result", "eqry", "result_index",
+                 "hidden_dim", "recon_loss", "THRESHOLD"):
+        assert not enc(name), name
+    # Structural flow still classifies, regardless of name.
+    gen._enc_vars.add("zzz_totally_plain_sounding")
+    assert enc("zzz_totally_plain_sounding")
 
 
 def test_ct_minus_column_slice():
@@ -339,23 +339,19 @@ def test_vec_zeros_type_arg_enc():
     assert "NullSafeEvalAdd(cc, buckets[i], xs[i])" in impl
 
 
-def test_heuristic_fallback_warns():
-    # When classification can only come from the name heuristic, the compiler
-    # records it and generate() surfaces a warning naming the variable.
-    from lexer import lex as _lex
-    from parser import parse as _parse
-    from semantic import analyze as _analyze
-    from codegen import generate as _generate
-    program = _parse(_lex("""
-    fn helper(x: f64) -> f64 { return x }
-    fn f() -> f64 {
+def test_unresolved_name_is_plain():
+    # A name the structural machinery cannot reach generates PLAIN C++ (which
+    # fails at C++ compile time if it was actually a ciphertext) — the fix is
+    # an annotation, never a naming convention.
+    files = compile_str("""
+    fn f(xs: vec<f64>) -> f64 {
+        let ct_mystery = xs[0]
         return ct_mystery + 1.0
     }
-    """))
-    sa = _analyze(program)
-    _generate(program, sa)
-    assert any("heuristic" in w and "ct_mystery" in w for w in sa.errors.warnings), \
-        sa.errors.warnings
+    """)
+    impl = files["nb_shared.cpp"]
+    assert "(ct_mystery + 1.0)" in impl
+    assert "EvalAdd(ct_mystery" not in impl
 
 
 def test_wire_layout_is_field_type_driven():


### PR DESCRIPTION
Roadmap item 5, the endgame. The original #1 weakness ("I had to name variables to please the compiler") is now fully dead: `ENCRYPTED_PREFIXES`/`ENCRYPTED_EXACT_NAMES`, the Ident fallback, the ALL_CAPS protection rule, the FieldAccess field-name guess, and the fallback-warning machinery are all **deleted**.

## Semantics

Classification is purely structural (annotations, builtin/user-fn return types, let-binding flow, loop elements, closure params, wire fields, destructured tuples). An unresolvable name is **plaintext** — if it was actually a ciphertext, the generated C++ fails to compile (never silently wrong), and the fix is an annotation, never a naming convention.

## Why now / how validated

- Evidence bar: all 7 examples at zero fallbacks, plus the cold-start fraud-flag dogfood with zero hits.
- **Strong validation**: generated C++ is **byte-identical** across all seven examples before/after removal (per-example `diff -rq` of full `nb_out`).
- The old test pinning the heuristic's false positives (`result_index`, `hidden_dim`, `recon_loss` — annotated "update if types replace it") is replaced by `test_no_name_heuristic`; `test_unresolved_name_is_plain` documents the new failure mode.
- 31/31 codegen + 23/23 semantic tests; `test-compiler` + `simple` + `set-membership` e2e pass (byte-identical codegen ⇒ remaining examples unaffected by construction).

Companion skill PR updates pitfall #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)