### PR TITLE
fraud-flag: pin Full at N=65536 (HW constraint) + advisor headroom reporting

### DIFF
--- a/dsl_fhe/examples/fraud-flag/README.md
+++ b/dsl_fhe/examples/fraud-flag/README.md
@@ -55,16 +55,24 @@ nothing and buys the fastest bulk numeric throughput.
 
 ## Stage 6 — Parameters
 
-`logQ ≈ first_mod + depth × q_i = 60 + 15×50 = 810 bits` → 128-classic fits
-at **ring_dim 32768** (one size smaller than the set-membership example,
-because the shorter L=16 vectors shrink C and therefore K). The compiler's
-params note confirms this exact computation at `nbc check` time:
+`logQ ≈ first_mod + depth × q_i = 60 + 15×50 = 810 bits` → 128-classic needs
+only **ring_dim 32768**. The deployment, however, pins **ring_dim = 65536**
+as a hard constraint (the hardware ring-dimension target) — above the
+security minimum, which is pure upside: 32,768 slots pack all 5,000 flagged
+cards in one batch, and the spare modulus budget is headroom the compiler
+quantifies at `nbc check` time:
 
 ```
 note: params: logQ ~= 810 bits (first_mod 60 + depth 15 x q_i 50);
-128-classic needs ring_dim >= 32768; declared ring_dims OK: [32768];
+128-classic needs ring_dim >= 32768; declared ring_dims OK: [65536];
+headroom at N=65536: 962 bits -> q_i up to 59 (+9 bits/level precision)
+or depth up to 34 (+19 levels);
 below target: [2048] (covered by scheme.override(security: not_set) dev profiles)
 ```
+
+The headroom line is the deployment-constrained tuning surface: raise `q_i`
+toward the limb cap for tighter precision, or spend levels on higher
+approximation degrees — without touching security.
 
 ## Stage 7 — Implementation (Track A)
 

--- a/dsl_fhe/examples/fraud-flag/shared.nb
+++ b/dsl_fhe/examples/fraud-flag/shared.nb
@@ -11,12 +11,15 @@
 //   - Encoding (harness/encode_cards.py): each digit d -> d+1 (values 1..10),
 //     so zero-padded batch rows can never match a real query.
 //   - Column-major SIMD: one ciphertext per digit position (L=16), one
-//     flagged card per slot; 5,000 cards -> 5 batches at 1,024 slots (Toy).
+//     flagged card per slot; 5 batches at 1,024 slots (Toy), one batch
+//     at 32,768 slots (Full).
 //   - Circuit per slot: S = sum_i (q_i - c_i)^2; t = 1 - S/C with
 //     C = 9^2 * 16 = 1296; t^(2^K) amplifies (match ~= 1, others -> 0);
 //     slot_sum aggregates. K: (1 - 1/C)^(2^K) < 0.01 -> K = 13 -> depth 15.
-//   - Parameters: logQ ~= 60 + 15*50 = 810 bits -> 128-classic fits at
-//     ring_dim 32768 (the compiler's params note confirms).
+//   - Parameters: logQ ~= 60 + 15*50 = 810 bits; deployment pins
+//     ring_dim = 65536 (hardware target) — above the 32768 security
+//     minimum, leaving ~962 bits of headroom (the params note quantifies
+//     what it buys in q_i / depth).
 //============================================================================
 
 enum Profile { Toy, Full }
@@ -34,7 +37,11 @@ fn instance(profile: Profile) -> Instance {
     match profile {
         Toy  => Instance { profile, ring_dim: 2048,  n_slots: 1024,
                            n_digits: 16, k_squarings: 13, depth: 15 },
-        Full => Instance { profile, ring_dim: 32768, n_slots: 16384,
+        // HARD deployment constraint: the hardware targets ring dim 2^16.
+        // Security needs only 32768 at logQ ~= 810 — the surplus is headroom
+        // (see the compiler's params note: larger q_i and/or more depth),
+        // and 32768 slots pack all 5,000 flagged cards in ONE batch.
+        Full => Instance { profile, ring_dim: 65536, n_slots: 32768,
                            n_digits: 16, k_squarings: 13, depth: 15 },
     }
 }

--- a/dsl_fhe/xcomp/semantic.py
+++ b/dsl_fhe/xcomp/semantic.py
@@ -128,6 +128,28 @@ class SemanticAnalyzer:
             low = sorted(n for n in self.ring_dims if not min_n or n < min_n)
             if ok:
                 msg += f"; declared ring_dims OK: {ok}"
+                # Fixed-N headroom: when the deployment pins N above the
+                # security minimum (e.g. a hardware ring-dimension target),
+                # quantify what the spare modulus budget buys — more bits per
+                # level (q_i, capped by the ~59-bit limb width) and/or more
+                # depth (higher approximation degrees).
+                n_top = max(ok)
+                spare = table[n_top] - log_q
+                if spare > 0:
+                    LIMB_CAP = 59
+                    max_qi = min(LIMB_CAP,
+                                 (table[n_top] - first) // self.max_depth)
+                    max_d = (table[n_top] - first) // q_i
+                    extras = []
+                    if max_qi > q_i:
+                        extras.append(f"q_i up to {max_qi} "
+                                      f"(+{max_qi - q_i} bits/level precision)")
+                    if max_d > self.max_depth:
+                        extras.append(f"depth up to {max_d} "
+                                      f"(+{max_d - self.max_depth} levels)")
+                    if extras:
+                        msg += (f"; headroom at N={n_top}: {spare} bits -> "
+                                + " or ".join(extras))
             if low:
                 msg += (f"; below target: {low}"
                         + (" (covered by scheme.override(security: not_set) "

--- a/dsl_fhe/xcomp/tests/test_semantic.py
+++ b/dsl_fhe/xcomp/tests/test_semantic.py
@@ -342,6 +342,21 @@ def test_encryptors_independent_forbids_cross_owner_packing():
     assert any("unknown mode" in str(e) for e in sa4.errors.errors), sa4.errors.errors
 
 
+def test_parameter_advisor_headroom():
+    # A ring_dim pinned ABOVE the security minimum (hardware target) gets a
+    # headroom report: spare modulus bits -> larger q_i (capped at the
+    # 59-bit limb) and/or more depth.
+    sa = check("""
+    scheme CKKS { security: 128-classic precision: 50 first_mod: 60 depth: 15 }
+    struct Instance { ring_dim: u32 }
+    fn instance() -> Instance { return Instance { ring_dim: 65536 } }
+    """)
+    note = next((n for n in sa.errors.notes if "headroom" in n), "")
+    assert "headroom at N=65536: 962 bits" in note, sa.errors.notes
+    assert "q_i up to 59 (+9 bits/level precision)" in note, note
+    assert "depth up to 34 (+19 levels)" in note, note
+
+
 if __name__ == "__main__":
     tests = [v for k, v in globals().items() if k.startswith("test_")]
     passed = 0


### PR DESCRIPTION
Review feedback on the fraud-flag example, issue 1: it "settled" on N=32768 because the advisor only answers *minimum N for security* — but the deployment pins **ring_dim = 65536** (hardware target) as a hard constraint, and the surplus is pure upside.

## Changes

- **fraud-flag `Full`** → `ring_dim: 65536` / 32,768 slots: all 5,000 flagged cards in **one batch**, README Stage 6 rewritten around the deployment constraint.
- **Advisor headroom reporting**: when a declared `ring_dim` exceeds the security minimum, the params note quantifies what the spare modulus budget buys:

```
note: params: logQ ~= 810 bits (first_mod 60 + depth 15 x q_i 50);
128-classic needs ring_dim >= 32768; declared ring_dims OK: [65536];
headroom at N=65536: 962 bits -> q_i up to 59 (+9 bits/level precision)
or depth up to 34 (+19 levels); ...
```

(q_i capped at the ~59-bit limb width.) The fixed-N tuning surface — precision vs. approximation depth at constant security — is now compile-time output instead of hand math. set-membership's note picks up its own headroom line too (812 bits at its declared 65536).

## Verification

24/24 semantic tests (headroom note pinned); all seven examples at 0 warnings; `test-fraud` end-to-end passes (toy profile unchanged, so runtimes are identical in CI).

Issue 2 from the same review (confusion matrix / 74% fraud-class accuracy) is a different workload class — the ML-track fraud-detection classifier — pending the plaintext model + labeled test set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)