### PR TITLE
Increate timeout

### DIFF
--- a/src/fhetch_transport/client.cpp
+++ b/src/fhetch_transport/client.cpp
@@ -136,7 +136,7 @@ int main(int argc, char** argv) {
     // ---- POST and wait -------------------------------------------------
     auto [host, _unused_path] = origin_of(server_url);
     httplib::Client cli(host);
-    cli.set_read_timeout(60 * 30, 0);   // 30 min for long replays
+    cli.set_read_timeout(60 * 120, 0);  // 2 hr — FUNC_SIM_HW on large workloads can exceed 30 min
     cli.set_write_timeout(60, 0);
     cli.set_connection_timeout(10, 0);
 

--- a/src/fhetch_transport/server.cpp
+++ b/src/fhetch_transport/server.cpp
@@ -267,7 +267,7 @@ int main(int argc, char** argv) {
     // the server closes the socket mid-upload and the client just sees a
     // "Failed to write connection" error.
     srv.set_payload_max_length((std::numeric_limits<size_t>::max)());
-    srv.set_read_timeout(60 * 30, 0);   // 30 min, matches the client's read timeout
+    srv.set_read_timeout(60 * 120, 0);  // 2 hr — matches client's read timeout
     std::signal(SIGINT,  shutdown_handler);
     std::signal(SIGTERM, shutdown_handler);
 


### PR DESCRIPTION
`FUNC_SIM_HW` replay of large FBS workloads (`ring_dim=65536`) takes over 30 minutes, causing the client to time out waiting for the server response and fail with "Failed to read connection". Bump both `set_read_timeout` calls to 2 hours