### PR TITLE
nbc: route wire output by data-flow direction (@client uploads vs @server results)

### DIFF
--- a/dsl_fhe/CLAUDE.md
+++ b/dsl_fhe/CLAUDE.md
@@ -405,6 +405,28 @@ not yet needed.
 **Fix**: The generated CMakeLists.txt lists external libraries twice on the link line,
 giving the linker a second pass to resolve cross-references.
 
+### 11. Wire Output Routed to the Wrong Transfer Directory
+
+**Problem**: `_find_output_dir()` routed *every* stage's serialized wire output to
+`ctxtdowndir(inst)` whenever that helper existed, ignoring data-flow direction. In a
+design with distinct upload/download dirs (`ctxtupdir` = `ct_in`, `ctxtdowndir` =
+`ct_out`), the `@client` encrypt stage's output — which is the *server's input* — was
+written to `ct_out`, while the `@server` stage read it (correctly, via an explicit
+`from: ctxtupdir(inst)`) from `ct_in`. The consuming stage therefore loaded an **empty**
+input wire and the first `x[i]` walked off the end of the vector, crashing with a
+segfault (`exit -11`) — and identically on the symmetric `decrypt` hand-off. It only
+escaped notice because the shipped examples use a single shared `encdir`. `writes()` has
+no `to:` clause, so the design could not override the destination; the fix had to be in
+codegen.
+
+**Fix**: `_find_output_dir()` is now data-flow aware: a `@client` stage's output routes
+to `ctxtupdir` (the upload the server consumes) when that helper exists; a `@server`
+stage's output routes to `ctxtdowndir` (the result the client consumes). Producer and
+consumer dirs now match on both hand-offs. Key/context wires are unaffected (canonical
+cc/pk/mk/rk layout), an explicit `to:` path still overrides, and single-dir (`encdir`)
+designs are unchanged since the `ctxtupdir` branch is gated on that helper existing.
+Pinned by `test_client_output_routes_to_upload_dir`.
+
 ## File Structure
 
 ```

--- a/dsl_fhe/xcomp/codegen.py
+++ b/dsl_fhe/xcomp/codegen.py
@@ -1558,9 +1558,30 @@ endforeach()
                 self.wl("}")
 
     def _find_output_dir(self, stage: StageInfo) -> str:
-        """Find the output directory for a stage from writes io specs or shared functions."""
-        # Check if ctxtdowndir or encdir functions exist
+        """Find the output directory for a stage's serialized wire output.
+
+        Data-flow aware. A @client stage's wire output is the *upload* the
+        server consumes, so it must land in the upload dir (`ctxtupdir`); a
+        @server stage's output is the *result* the client consumes, so it
+        lands in the download dir (`ctxtdowndir`). Routing every output to
+        `ctxtdowndir` (the previous behavior) silently breaks any design that
+        declares distinct upload/download dirs: the @client encrypt stage
+        wrote the server's input into the download dir while the @server
+        stage read it from the upload dir, producing an empty input wire and
+        an out-of-bounds crash in the consuming stage (observed as the
+        reference twin segfaulting with exit -11).
+
+        Key/context wires never reach here — they use the canonical
+        cc/pk/mk/rk layout via `_gen_serialize_crypto_params`. An explicit
+        `to:` path on the `writes()` clause also overrides this default
+        upstream (see `_gen_serialize_io`). Single-dir designs (only `encdir`)
+        are unaffected: the `ctxtupdir` branch is gated on that helper
+        existing.
+        """
         fn_names = {f.name for f in self.shared_fns}
+        # Client uploads flow "up" to the server; server results flow "down".
+        if stage.domain == Domain.CLIENT and "ctxtupdir" in fn_names:
+            return "ctxtupdir(inst)"
         if "ctxtdowndir" in fn_names:
             return "ctxtdowndir(inst)"
         if "encdir" in fn_names:

--- a/dsl_fhe/xcomp/tests/test_codegen.py
+++ b/dsl_fhe/xcomp/tests/test_codegen.py
@@ -73,6 +73,45 @@ def test_stage_generates_cpp():
     assert "auto size = static_cast" in cpp
 
 
+def test_client_output_routes_to_upload_dir():
+    """A @client stage's wire output is the server's input — it must serialize
+    to the upload dir (ctxtupdir), not the download dir.
+
+    Regression for the dir-routing bug where _find_output_dir routed every
+    stage output to ctxtdowndir whenever that helper existed. With distinct
+    upload/download dirs, the @client encrypt stage wrote the server's input
+    into the download dir while the @server stage read it from the upload
+    dir, producing an empty input wire and an out-of-bounds crash in the
+    consuming stage. The producer dir must match the consumer's read dir:
+    @client -> ctxtupdir, @server -> ctxtdowndir.
+    """
+    files = compile_str("""
+    wire Payload { items: vec<enc<f64>> }
+    struct Instance { ring_dim: u32 }
+    enum InstanceSize { Dev }
+    fn instance(size: InstanceSize) -> Instance { match size { Dev => Instance { ring_dim: 2048 } } }
+    fn iodir(inst: Instance) -> path { root() / "io" }
+    fn ctxtupdir(inst: Instance) -> path { iodir(inst) / "ct_in" }
+    fn ctxtdowndir(inst: Instance) -> path { iodir(inst) / "ct_out" }
+    @client @stage(name: "upload")
+    fn upload(inst: Instance) -> writes(Payload) {
+        return Payload { items: [zero()] }
+    }
+    @server @stage(name: "compute")
+    fn compute(inst: Instance) -> reads(Payload), writes(Payload) {
+        let p = load(Payload, from: ctxtupdir(inst))
+        return Payload { items: [zero()] }
+    }
+    """)
+    # @client upload writes where the @server reads its input from.
+    up = files["upload.cpp"]
+    assert "ctxtupdir(inst)" in up
+    assert "ctxtdowndir(inst)" not in up
+    # @server compute writes its result where the @client decrypt reads from.
+    comp = files["compute.cpp"]
+    assert "ctxtdowndir(inst)" in comp
+
+
 def test_stage_with_hardware():
     files = compile_str("""
     struct Instance { ring_dim: u32 }


### PR DESCRIPTION
## Summary
`_find_output_dir()` routed **every** stage's serialized wire output to
`ctxtdowndir` whenever that helper existed, ignoring data-flow direction. In a
design that declares distinct upload/download dirs (`ctxtupdir` = `ct_in`,
`ctxtdowndir` = `ct_out`), the `@client` encrypt stage wrote the **server's
input** into the download dir while the `@server` stage read it from the upload
dir. The consuming stage then loaded an **empty** input wire and the first
indexed access ran off the end of the vector — a segfault that surfaces as the
reference twin's `exit -11`. The decrypt hand-off fails symmetrically. The
shipped examples escaped this only because they use a single shared `encdir`.

## Root cause
The directory convention was role-agnostic — inputs read from `ctxtupdir`,
outputs written to `ctxtdowndir`, regardless of which party produces or
consumes a given wire. That holds for a lone `@server` compute stage but breaks
the client→server hand-off, whose producer output must land where the server
reads it. `writes()` has no `to:` clause, so a design can't override it; the
fix has to be in codegen.

## Fix
Make `_find_output_dir()` data-flow aware:
- `@client` stage output → `ctxtupdir` (the upload the server consumes)
- `@server` stage output → `ctxtdowndir` (the result the client consumes)

Producer and consumer directories now match on both hand-offs.

## Compatibility
- **Key/context wires unaffected** — they use the canonical `cc/pk/mk/rk`
  layout via `_gen_serialize_crypto_params`, not `_find_output_dir`.
- **Explicit `to:` paths still override** (handled upstream in the serialize
  path).
- **Single-dir designs unchanged** — the `ctxtupdir` branch is gated on that
  helper existing, so `encdir`-only examples behave exactly as before.

## Testing
- New regression `test_client_output_routes_to_upload_dir` (a `@client` stage
  serializes to `ctxtupdir`, a `@server` stage to `ctxtdowndir`).
- Full `xcomp` unit suite green (105).
- Verified at runtime: the regenerated fraud design has encode writing
  `ctxtupdir` / compute reading `ctxtupdir` (match) and compute writing
  `ctxtdowndir` / decrypt reading `ctxtdowndir` (match), in both the real and
  `_ref` twin stages. `make test-examples` passes.
- Documented as known-pitfall #11 in `dsl_fhe/CLAUDE.md`.
