### PR TITLE
chore: switch submodules to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,10 @@
 [submodule "vendor/niobium-fhetch"]
 	path = vendor/niobium-fhetch
-	url = git@github.com:NiobiumInc/niobium-fhetch.git
+	url = https://github.com/NiobiumInc/niobium-fhetch.git
 [submodule "vendor/niobium-haze"]
 	path = vendor/niobium-haze
-	url = git@github.com:NiobiumInc/niobium-haze.git
+	url = https://github.com/NiobiumInc/niobium-haze.git
 [submodule ".claude/skills/fhe-application-design"]
 	path = .claude/skills/fhe-application-design
-	url = git@github.com:NiobiumInc/fhe-application-design.git
+	url = https://github.com/NiobiumInc/fhe-application-design.git
 	branch = main


### PR DESCRIPTION
## What
Switch the three submodule URLs in `.gitmodules` from SSH to HTTPS:
- `vendor/niobium-fhetch`
- `vendor/niobium-haze`
- `.claude/skills/fhe-application-design`

## Why
This repo is consumed as a public submodule of `fetch-by-similarity-submission`. With the parent already on HTTPS, a `git clone --recurse-submodules` by a keyless evaluator currently fails here, because these nested submodules still use `git@github.com:`. All three target repos are public, so HTTPS works anonymously.

SSH-preferring contributors don't need to edit `.gitmodules` — they can opt back in globally with:
```
git config --global url."git@github.com:".insteadOf "https://github.com/"
```

> Note: separately, you may want to decide whether `.claude/skills/fhe-application-design` belongs in the public release at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)