### PR TITLE
Chore/update install docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,10 +28,14 @@ See [`README.md`](README.md) for the full narrative and diagrams.
 ## Development Commands
 
 ```bash
-git submodule update --init --recursive   # or: make sync-submodules
+make sync                 # git submodule update --init --recursive
 
-make build-release        # build OpenFHE + libnbfhetch + examples (Release)
-make build                # same, Debug
+make release              # configure + build OpenFHE + libnbfhetch + examples (Release)
+make config && make build # same, Debug (config once, then build)
+
+# On an already-configured tree you can rebuild without re-configuring:
+make build-release        # incremental Release build (requires a prior `make release`/config)
+make build                # incremental Debug build   (requires a prior `make config`)
 
 make test-release         # run the example/replay test sweep (Release)
 make test-mult-release    # CKKS EvalMult: record → replay → decrypt

--- a/README.md
+++ b/README.md
@@ -276,8 +276,8 @@ Niobium hardware with minimal porting effort: swap the `cuda*` calls for
 ### Fresh Build
 
 ```bash
-make sync                # git submodule update --init --recursive
-make release             # configure + build everything (Release)
+make sync                 # git submodule update --init --recursive
+make release              # configure + build everything (Release)
 make config && make build # same, Debug (config once, then build)
 ```
 

--- a/README.md
+++ b/README.md
@@ -273,16 +273,23 @@ Niobium hardware with minimal porting effort: swap the `cuda*` calls for
 
 ## Building
 
+### Fresh Build
+
 ```bash
 make sync                # git submodule update --init --recursive
 make release             # configure + build everything (Release)
+make config && make build # same, Debug (config once, then build)
 ```
 
-`make release` runs the CMake configure step (`config-release`) and then the
-build (`build-release`) — use it for a fresh clone. Once the tree is configured,
-`make build-release` rebuilds incrementally without re-configuring (running it on
-an unconfigured tree fails, since it only invokes `cmake --build`). For a Debug
-build, run `make config` once and then `make build`.
+### Incremental Build
+
+```bash
+make sync
+make build-release        # build OpenFHE + libnbfhetch + examples (Release)
+make build                # same, Debug
+```
+
+### Build Pipeline
 
 The top-level `Makefile` builds OpenFHE (vendored at
 `vendor/niobium-fhetch/vendor/openfhe`), installs it under

--- a/README.md
+++ b/README.md
@@ -274,9 +274,15 @@ Niobium hardware with minimal porting effort: swap the `cuda*` calls for
 ## Building
 
 ```bash
-git submodule update --init --recursive
-make build-release       # or: make build  (Debug)
+make sync                # git submodule update --init --recursive
+make release             # configure + build everything (Release)
 ```
+
+`make release` runs the CMake configure step (`config-release`) and then the
+build (`build-release`) — use it for a fresh clone. Once the tree is configured,
+`make build-release` rebuilds incrementally without re-configuring (running it on
+an unconfigured tree fails, since it only invokes `cmake --build`). For a Debug
+build, run `make config` once and then `make build`.
 
 The top-level `Makefile` builds OpenFHE (vendored at
 `vendor/niobium-fhetch/vendor/openfhe`), installs it under


### PR DESCRIPTION
The README and AGENTS.md quickstarts told a fresh clone to run `make build-release`, but that target only invokes `cmake --build` and has no configure prerequisite, so it fails on an unconfigured tree.

Lead with `make release` (config-release + build-release) instead, and relabel `make build-release`/`make build` as incremental rebuilds.

Also standardize the submodule step on `make sync` (the repo-family's public umbrella target) instead of the raw git command / internal `sync-submodules` name.