### PR TITLE
Make the FHE design skill discoverable from every entry point

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,14 @@
 
 Guidance for Claude Code (and other agents) working in this repository.
 
+> **Designing or building an FHE application? Read
+> [`.claude/skills/fhe-application-design/SKILL.md`](.claude/skills/fhe-application-design/SKILL.md)
+> first — do not skip the design stages.** It is an 8-stage design guide (privacy
+> model → feasibility → scheme → circuit → SIMD data layout → parameters →
+> codegen). This applies whether you enter through the nb DSL (`dsl_fhe/`),
+> instrumented OpenFHE (`examples/`), or direct FHETCH IR — the design work comes
+> before the code either way.
+
 ## Project Overview
 
 **Niobium Client** is the open-source client stack for the Niobium Mistic FHE

--- a/dsl_fhe/AGENTS.md
+++ b/dsl_fhe/AGENTS.md
@@ -1,5 +1,14 @@
 # DSL for FHE: Design Rationale and Compiler Guide
 
+> **Building an FHE app? Read the design skill first — do not skip the design
+> stages.** Before you write a single `.niob` file, read
+> [`../.claude/skills/fhe-application-design/SKILL.md`](../.claude/skills/fhe-application-design/SKILL.md).
+> It walks you from problem statement through privacy model, feasibility, scheme
+> selection, circuit design, SIMD data layout, and parameter selection. Copying an
+> example without doing this design work is the most common way to ship a
+> working-but-wrong FHE application. This file (design rationale + codegen
+> internals) is *reference*, not the starting point.
+
 ## Quick Start
 
 ```bash
@@ -17,6 +26,7 @@ make set-membership         # Build the private name-matching example
 
 | File | Purpose |
 |---|---|
+| **`../.claude/skills/fhe-application-design/SKILL.md`** | **START HERE for a new app** — 8-stage design guide (privacy model → feasibility → scheme → circuit → data layout → parameters → codegen). Read before writing `.niob`. |
 | `AGENTS.md` | This file — design rationale, codegen internals, known pitfalls (imported by `CLAUDE.md`, or read directly by non-Claude agents) |
 | `HOWTO.md` | Step-by-step guide for adding a new example |
 | `NB_LANGUAGE.md` | Language reference — types, syntax, built-in functions, patterns |

--- a/dsl_fhe/CLAUDE.md
+++ b/dsl_fhe/CLAUDE.md
@@ -1,3 +1,10 @@
 # CLAUDE.md
 
+> **Building an FHE app with this DSL? STOP and read
+> [`../.claude/skills/fhe-application-design/SKILL.md`](../.claude/skills/fhe-application-design/SKILL.md)
+> first.** It is an 8-stage design guide (privacy model → feasibility → scheme →
+> circuit → data layout → parameters → codegen). Do not skip the design stages and
+> jump straight to copying an example — that is the most common way to get a
+> working-but-wrong FHE application.
+
 @./AGENTS.md

--- a/dsl_fhe/README.md
+++ b/dsl_fhe/README.md
@@ -4,6 +4,12 @@ A domain-specific language and cross-compiler for writing Fully Homomorphic Encr
 applications. The DSL compiles `.niob` source files to C++ with openFHE, producing
 self-contained binaries for a client-server FHE pipeline.
 
+> **Designing a new app? Load the design skill first.** Before writing `.niob`,
+> read [`../.claude/skills/fhe-application-design/SKILL.md`](../.claude/skills/fhe-application-design/SKILL.md)
+> — an 8-stage guide from problem statement through privacy model, feasibility,
+> scheme selection, circuit design, data layout, and parameter selection. The DSL
+> is how you *express* an FHE app; the skill is how you *design* one correctly.
+
 ## Motivation
 
 ### The Boilerplate Problem

--- a/dsl_fhe/xcomp/nbc.py
+++ b/dsl_fhe/xcomp/nbc.py
@@ -24,6 +24,20 @@ from semantic import analyze as semantic_analyze
 from codegen import generate
 from errors import CompileError
 
+# One-line pointer to the design skill. Printed to stderr by check/compile so an
+# agent that lands on `nbc` without having read the docs still gets nudged to the
+# 8-stage design guide before hand-writing a circuit. See discoverability notes in
+# dsl_fhe/AGENTS.md.
+_DESIGN_SKILL = ".claude/skills/fhe-application-design/SKILL.md"
+
+
+def _print_design_banner():
+    print(
+        f"nbc: building an FHE app? Read the design skill first — {_DESIGN_SKILL} "
+        f"(8 stages; don't skip the design work).",
+        file=sys.stderr,
+    )
+
 
 def cmd_lex(args):
     """Tokenize input files and print tokens."""
@@ -57,6 +71,7 @@ def cmd_parse(args):
 
 def cmd_check(args):
     """Parse and run semantic analysis on input files."""
+    _print_design_banner()
     combined_source, tokens = _lex_all(args.files)
     if tokens is None:
         return 1
@@ -81,6 +96,7 @@ def cmd_check(args):
 
 def cmd_compile(args):
     """Compile .niob files to OpenFHE C++."""
+    _print_design_banner()
     combined_source, tokens = _lex_all(args.files)
     if tokens is None:
         return 1


### PR DESCRIPTION
## Problem

Agents (and readers arriving from articles) that enter at `dsl_fhe/` were missing the `fhe-application-design` skill entirely. Three compounding reasons:

- The skill lives in dot-directories (`.claude/skills/`, `.agents/skills/`) that scoped exploration (`find dsl_fhe -type f`) never surfaces.
- The entry-point docs only mentioned it in passing — root `AGENTS.md` described it as architecture prose ("the nb DSL + design skill"), easy to skim past; `dsl_fhe/CLAUDE.md` was just `@./AGENTS.md`.
- Nothing *forced* the reader to climb to the repo root — discovery depended on reading a doc that's easy to skip.

## Changes

Put imperative pointers **where the agent actually lands**, plus a nudge on the one command every FHE app is guaranteed to run.

- **`nbc` as the forcing function** — `nbc check`/`nbc compile` now print a one-line banner to **stderr** pointing at `SKILL.md`. stderr keeps stdout (`OK:`, `wrote …`) clean, so nothing parsing generated output breaks; compiler unit tests unaffected.
- **Imperative entry-point callouts** replacing skimmable prose in `dsl_fhe/CLAUDE.md`, `dsl_fhe/AGENTS.md` (callout + a START HERE row in the doc map), root `AGENTS.md`, and `dsl_fhe/README.md` (the article-referral path).

Docs + one stderr line only — no change to codegen or the generated C++.

## Not included

A machine-readable skill manifest was deliberately left out — the `AGENTS.md` skill-index / agentskills.io conventions aren't firm yet, so it'd be premature maintenance debt. Worth revisiting once a convention stabilizes.

## Test plan

- [x] `make test-compiler` passes (unit tests + example checks)
- [x] `nbc check` banner confirmed on stderr; stdout stays clean; exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)