### PR TITLE
Force-include `<cstdint>` for the fetched `yaml-cpp`

### DIFF
--- a/src/auto_facade/CMakeLists.txt
+++ b/src/auto_facade/CMakeLists.txt
@@ -36,6 +36,14 @@ if(NOT yaml-cpp_FOUND)
         GIT_SHALLOW    TRUE
     )
     FetchContent_MakeAvailable(yaml_cpp)
+    # yaml-cpp 0.8.0's emitterutils.cpp uses uint16_t/uint32_t without
+    # #include <cstdint>, which newer clang/gcc libstdc++ headers no longer
+    # supply transitively. Force-include it for this target only, leaving the
+    # vendored source untouched (mirrors the -Wno-restrict scoping elsewhere).
+    # Scoped to C++ TUs via COMPILE_LANGUAGE. (MSVC would need "/FI cstdint"
+    # instead of "-include cstdint" should Windows ever be supported.)
+    target_compile_options(yaml-cpp PRIVATE
+        "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-include cstdint>")
 endif()
 
 add_library(niobium_client_autofacade STATIC


### PR DESCRIPTION
## Problem

`src/auto_facade/CMakeLists.txt` fetches yaml-cpp 0.8.0 via FetchContent. That
release's `src/emitterutils.cpp` uses `uint16_t`/`uint32_t` without
`#include <cstdint>`, relying on the header being pulled in transitively.
Newer toolchains (e.g. clang 21, gcc 14) no longer do so under their stricter
libstdc++ headers, so a fresh build fails:

```
error: unknown type name 'uint32_t'
error: use of undeclared identifier 'uint16_t'
```

This breaks a clean auto-facade build on current compilers (surfaced from a
fresh clang release build; gcc 14 reproduces it too).

## Fix

Scope a `-include cstdint` compile option to the `yaml-cpp` target only, right
after `FetchContent_MakeAvailable(yaml_cpp)`:

```cmake
target_compile_options(yaml-cpp PRIVATE
    "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-include cstdint>")
```

- Leaves the vendored yaml-cpp source untouched (consistent with the adjacent
  `CMAKE_POLICY_VERSION_MINIMUM` workaround) and mirrors the existing
  `-Wno-restrict` scoping on the same target.
- `COMPILE_LANGUAGE:CXX` restricts the flag to C++ translation units, so any C
  sources are unaffected; `SHELL:` keeps `-include cstdint` as two argv tokens.
- MSVC would need `/FI cstdint` instead — noted in a comment for if/when
  Windows support is added; not applicable to the current Linux/macOS matrix.

## Verification

- Isolated CMake project: the genex delivers `-include cstdint` (two tokens) on
  the C++ compile and nothing on a C compile; the C++ TU using `uint16_t` with
  no include builds.
- Real yaml-cpp target builds cleanly under `clang 21.1.8` and `g++ 14.2.0`,
  with `-include cstdint` confirmed on the `emitterutils.cpp` command line.
- No behavior change for toolchains that already pull in `<cstdint>`
  transitively.
