### PR TITLE
fix(auto-facade): clean up replay-mode probe handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,15 @@ test-plaintext-add-release: build-release ## Run the plaintext-add example: clie
 # auto-facade's template+refill path for relin-based ops. Tracked as
 # a follow-up simulator-precision task.
 #
-# Override AUTO_OP=MUL AUTO_EXPECTED=21 to reproduce the failure mode.
+# Update (2026-07-17, niobium-fhetch @ c387dce): MUL now passes both
+# the record and the cache-hit replay decrypt. The replay pass used to
+# log spurious "[NIOBIUM] Result 'output_N' not found" lines; both
+# sources are fixed in AutoFacade.cpp (substituted-ciphertext tracking
+# in on_decrypt, and a serialized_probes/ guard in
+# on_serialize_ciphertext so reconstruct_probes' own writes are not
+# intercepted).
+#
+# Override AUTO_OP=MUL AUTO_EXPECTED=21 to run the MUL variant.
 AUTO_OP        ?= ADD
 AUTO_A         ?= 7
 AUTO_B         ?= 3

--- a/src/auto_facade/AutoFacade.cpp
+++ b/src/auto_facade/AutoFacade.cpp
@@ -33,6 +33,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 // ---------------------------------------------------------------------------
@@ -116,6 +117,15 @@ static thread_local bool g_in_make_plaintext_hook = false;
 // Track probed ciphertext pointers -> probe name, to avoid double-probing
 // and to let on_decrypt use the same name that on_serialize used.
 static std::unordered_map<const void*, std::string> g_probed_cts;
+
+// Replay only: ciphertexts whose contents already ARE the reconstructed HW
+// result — substituted by on_decrypt or refreshed in place by
+// on_serialize_ciphertext. The instrumented Decrypt re-enters itself on a
+// substituted ct (to skip the recording guards), so on_decrypt must recognize
+// these and let the real decrypt proceed instead of minting a fresh
+// "output_<N>" probe name and re-fetching (the name would miss, logging a
+// spurious "Result 'output_<N>' not found").
+static std::unordered_set<const void*> g_substituted_cts;
 
 // Thread-local re-entry flag set when the facade itself issues
 // OpenFHE deserializations (e.g. Compiler::result loading a
@@ -590,6 +600,16 @@ bool on_serialize_ciphertext(const std::string &filepath,
 
   const std::string stem = path_stem(filepath);
 
+  // Facade-internal write: reconstruct_probes serializing
+  // serialized_probes/<name>.ct fires this hook too (mirrors the
+  // serialized_probes guard in on_deserialize_ciphertext). Let it proceed
+  // untouched — asking result() for the very probe reconstruct_probes is
+  // writing right now would log a spurious "Result '<name>' not found" on
+  // the first replay pass, and on later passes pointlessly rewrite the
+  // file with its own previous contents.
+  if (filepath.find("serialized_probes") != std::string::npos)
+    return false;
+
   if (g_replay_mode) {
     ensure_replayed();
     // Retrieve the hardware-computed result and write it to the output file.
@@ -611,6 +631,7 @@ bool on_serialize_ciphertext(const std::string &filepath,
         // Update the in-memory ciphertext with the HW result so subsequent
         // Decrypt on this ct gets the real data instead of dummy polynomials.
         ct->SetElements(hw_ct->GetElements());
+        g_substituted_cts.insert(ct.get());
         return true; // result found + HW ct written, skip normal serialize
       }
     }
@@ -662,12 +683,21 @@ bool on_decrypt(lbcrypto::Ciphertext<lbcrypto::DCRTPoly> &ct) {
 
   if (g_replay_mode) {
     ensure_replayed();
+    // This ct already holds the reconstructed HW result (substituted by a
+    // prior hook call, or refreshed in place by on_serialize_ciphertext):
+    // decrypt it as-is. This also terminates the instrumented Decrypt's
+    // re-entrant call on the substituted ciphertext.
+    if (g_substituted_cts.count(ct.get()))
+      return false;
     // Look up the HW-computed result by the same name used during recording
     if (g_cc) {
       lbcrypto::Ciphertext<lbcrypto::DCRTPoly> hw_ct;
       InFacadeIoGuard _facade_io;
       if (niobium::compiler().result(g_cc, name, hw_ct) && hw_ct) {
+        g_probed_cts[ct.get()] = name; // repeat decrypts of the dummy reuse this name
         ct = hw_ct; // substitute the dummy with the real HW result
+        g_probed_cts[ct.get()] = name;
+        g_substituted_cts.insert(ct.get());
         return false; // proceed with normal decrypt on the HW result
       }
     }


### PR DESCRIPTION
Bottom of a 4-PR stack: this one → #230 → #231 → #232.

Two sources of spurious `[NIOBIUM] Result 'output_N' not found` logs on cache-hit replay, both in `src/auto_facade/AutoFacade.cpp`:

- **Probe-name drift**: the instrumented `Decrypt` re-enters itself on the substituted ciphertext, and `on_decrypt` never recorded the substitution — so the re-entrant call minted a fresh `output_N` name whose lookup failure was, accidentally, what terminated the recursion. Now substituted ciphertexts are tracked (`g_substituted_cts`) and decrypted as-is; repeat decrypts reuse their recorded name.
- **Self-interception**: `on_serialize_ciphertext` intercepted `reconstruct_probes`' own writes to `serialized_probes/<name>.ct` and asked `result()` for the probe being written at that moment. Skip `serialized_probes/` paths, mirroring the existing guard in `on_deserialize_ciphertext`.

Also updates the stale Makefile comment (MUL passes since the fhetch bump to c387dce).

**Verified**: fresh record + cache-hit replay for ADD/MUL/ADDI are log-clean and pass; `make test-client-release` and all seven `dsl_fhe` examples pass.
