### PR TITLE
docs: README audit fixes (snippets, build, stage lists)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,9 @@ Guidance for Claude Code (and other agents) working in this repository.
 > **Designing or building an FHE application? Read
 > [`.claude/skills/fhe-application-design/SKILL.md`](.claude/skills/fhe-application-design/SKILL.md)
 > first — do not skip the design stages.** It is an 8-stage design guide (privacy
-> model → feasibility → scheme → circuit → SIMD data layout → parameters →
-> codegen). This applies whether you enter through the nb DSL (`dsl_fhe/`),
+> model → feasibility → plaintext ground truth → scheme → circuit → parameters →
+> implementation → protocol spec). This applies whether you enter through the nb
+> DSL (`dsl_fhe/`),
 > instrumented OpenFHE (`examples/`), or direct FHETCH IR — the design work comes
 > before the code either way.
 

--- a/README.md
+++ b/README.md
@@ -121,8 +121,11 @@ directly.
 ### Step by step
 
 1. **Compile & Link** — Build your OpenFHE application against `libnbfhetch`
-   and the Niobium-instrumented OpenFHE branch. Add `niobium::compiler().init()`,
-   `start()`, `stop()` around the computation. No changes to FHE algorithm code.
+   and the Niobium-instrumented OpenFHE branch (both produced by `make release`;
+   see [Linking your own application](#linking-your-own-application) for the
+   exact CMake recipe, including the required `OPENFHE_CPROBES` define). Add
+   `niobium::compiler().init()`, `start()`, `stop()` around the computation.
+   No changes to FHE algorithm code.
 
 2. **Execute** — Every OpenFHE polynomial operation (`NTT`, `INTT`, `ADD`,
    `SUB`, `MUL`, `MULI`, `ADDI`, `MORPH`, …) triggers a C probe
@@ -316,6 +319,72 @@ one tree.
 - OpenFHE (Niobium-instrumented branch, reached transitively through
   `vendor/niobium-fhetch/vendor/openfhe`)
 - Python 3 (DSL compiler + example harnesses)
+
+### Linking your own application
+
+A `make release` of this repo produces everything your application needs:
+the instrumented OpenFHE install under `vendor/lib/openfhe` and
+`libnbfhetch` under `build/vendor/niobium-fhetch`. Build your app against
+those with CMake:
+
+```cmake
+cmake_minimum_required(VERSION 3.16)
+project(my_app LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+
+# Path to your niobium-client checkout, already built with `make release`.
+set(NIOBIUM_CLIENT_ROOT "/path/to/niobium-client" CACHE PATH "niobium-client repo root")
+
+# REQUIRED: activates the recording probes compiled into your own translation
+# units. Without it your app still builds and runs, but the trace it records
+# is incomplete and replays garbage.
+add_compile_definitions(OPENFHE_CPROBES)
+
+set(OPENFHE_INC "${NIOBIUM_CLIENT_ROOT}/vendor/lib/openfhe/include/openfhe")
+include_directories(
+  "${OPENFHE_INC}" "${OPENFHE_INC}/core" "${OPENFHE_INC}/pke" "${OPENFHE_INC}/binfhe"
+  "${OPENFHE_INC}/third-party/include"
+  "${NIOBIUM_CLIENT_ROOT}/vendor/niobium-fhetch/include")
+
+find_library(NBFHETCH_LIB nbfhetch
+  PATHS "${NIOBIUM_CLIENT_ROOT}/build/vendor/niobium-fhetch" NO_DEFAULT_PATH)
+set(OPENFHE_LIB_DIR "${NIOBIUM_CLIENT_ROOT}/vendor/lib/openfhe/lib")
+link_directories("${OPENFHE_LIB_DIR}")
+
+add_executable(my_app my_app.cpp)
+target_link_libraries(my_app PRIVATE ${NBFHETCH_LIB} OPENFHEpke OPENFHEcore OPENFHEbinfhe)
+if(NOT APPLE)
+  target_link_options(my_app PRIVATE "LINKER:--no-as-needed")
+endif()
+set_target_properties(my_app PROPERTIES
+  BUILD_RPATH "${OPENFHE_LIB_DIR};${NIOBIUM_CLIENT_ROOT}/build/vendor/niobium-fhetch")
+```
+
+```bash
+cmake -B build -DNIOBIUM_CLIENT_ROOT=/path/to/niobium-client -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j
+```
+
+Two things deserve emphasis:
+
+- **`OPENFHE_CPROBES` is not optional.** The recording probes live in
+  instrumented OpenFHE *header* code that gets compiled into your translation
+  units. In-tree targets inherit the define automatically (the
+  `niobium_fhetch` CMake target exports it as `PUBLIC`), but when you link
+  `libnbfhetch` by path you must define it yourself. An app compiled without
+  it links and runs — and silently records a trace that is missing the
+  header-inlined polynomial ops, so a later cache-hit replay reconstructs
+  garbage.
+- **Runtime library paths.** The template sets `BUILD_RPATH` so the binary
+  finds `libOPENFHE*.so` and `libnbfhetch.so` without help; if you drop that,
+  set `LD_LIBRARY_PATH` to the two lib directories instead.
+
+If you use cooperative auto-tagging (`enable_auto_tagging()`) rather than
+manual `tag_input`/`tag_keys` calls, additionally link
+`libniobium_client_autofacade` (from `build/src/auto_facade`) with
+`--whole-archive` plus `yaml-cpp` — see the auto-generated
+`dsl_fhe/examples/*/nb_out/CMakeLists.txt` for a complete worked build that
+does exactly this.
 
 ### Updating the vendored design skill
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,12 @@ directly.
 #include "openfhe.h"
 #include "niobium/compiler.h"
 
+// OpenFHE serialization support — required for Serial::(De)SerializeFromFile.
+#include "ciphertext-ser.h"
+#include "cryptocontext-ser.h"
+#include "key/key-ser.h"
+#include "scheme/ckksrns/ckksrns-ser.h"
+
 using namespace lbcrypto;
 
 int main(int argc, char* argv[]) {
@@ -185,10 +191,12 @@ int main(int argc, char* argv[]) {
         niobium::compiler().probe("result", result);
         niobium::compiler().stop();
         // .fhetch + fhetch_replay.json are now written to disk.
-    } else {
-        // ---- REPLAY (cache hit: zero FHE ops on the host) ----
-        niobium::compiler().replay();
     }
+    // ---- REPLAY ----
+    // Always replay: result() below rehydrates from the replay output.
+    // On a cache-valid run this is all that executes — zero FHE ops on the host.
+    niobium::compiler().replay();
+
     Ciphertext<DCRTPoly> ct_result;
     niobium::compiler().result(cc, "result", ct_result);
     Serial::SerializeToFile("keys/ct_result.bin", ct_result, SerType::BINARY);
@@ -223,7 +231,7 @@ plaintexts come after keys.
 |---|---|
 | `examples/bootstrap/` | CKKS bootstrap under hollow recording (large trace, full replay) |
 | `examples/mult/` | CKKS `EvalMult` — client/server/decrypt split with replay + rehydrate |
-| `examples/simple_ops/` | 13 ops (ADD, SUB, MUL, NEG, ADDI/SUBI/MULI, compound chains, MORPH) driven by one harness |
+| `examples/simple_ops/` | 14 ops (ADD, SUB, MUL, NEG, ADDI/SUBI/MULI, compound chains, MORPH) driven by one harness |
 
 ```bash
 make test-simple-ops-release
@@ -286,10 +294,12 @@ make config && make build # same, Debug (config once, then build)
 
 ### Incremental Build
 
+On an already-configured tree (i.e. after a prior `make release` or
+`make config`) you can rebuild without re-configuring:
+
 ```bash
-make sync
-make build-release        # build OpenFHE + libnbfhetch + examples (Release)
-make build                # same, Debug
+make build-release        # incremental Release build (requires a prior `make release`)
+make build                # incremental Debug build   (requires a prior `make config`)
 ```
 
 ### Build Pipeline
@@ -430,7 +440,7 @@ credentials described below.
 |---|---|
 | `fog init [-f\|--force]` | Write `~/.fog/config` with default values (edit to taste). `--force` overwrites an existing file. |
 | `fog login [-u\|--username EMAIL] [-n\|--name NAME]` | Authenticate (OAuth2 password flow) and provision a **named** API key, saved to `~/.fog/credentials` (`0600`). Prompts for email/password if not given; `-n` labels the key (default `fog@<hostname>`). Adds a key — existing keys stay valid. Also prints the raw token to stdout, so `export FOG_API_TOKEN=$(fog login)` works. |
-| `fog submit ./app --target=T [args…]` | **Wrapper mode** — provision a job for target `T`, wait for a worker, then run your OpenFHE app `./app` against it (extra args pass through to the app). |
+| `fog submit ./app --target=T [args…]` | **Wrapper mode** — provision a job for target `T`, wait for a worker, then run your OpenFHE app `./app` against it (extra args pass through to the app). With no app (`fog submit --target=T [args…]`) it execs the `nbcc_fhetch_replay` transport client directly. |
 | `fog list` | Table of all your jobs (id, status, mode, target, worker, enqueued time) with an in-flight count. |
 | `fog get ID [ID…]` | Full JSON detail for one or more job ids. |
 | `fog cancel ID [ID…]` | Cancel/release specific jobs. |
@@ -462,7 +472,7 @@ config file → built-in default**.
 | `FOG_JOB_MAXWAIT` | Total seconds to keep polling the queue | `600` |
 | `FOG_HOME` | Config/credentials directory | `~/.fog` |
 | `NBCC_FHETCH_REPLAY_BIN` | Path to the `nbcc_fhetch_replay` client `fog` hands off to | `PATH`, then `build/` |
-| `NBCC_FHETCH_REPLAY` | Set to `fog` to enable driver mode (see above) | unset |
+| `NBCC_FHETCH_REPLAY` | Set to `fog` to enable driver mode: your app's `replay()` spawns `fog` itself, which provisions the job and hands off to `nbcc_fhetch_replay` — no `fog submit` wrapper needed (details in the `scripts/fog` header comment) | unset |
 
 **TLS note** — `fog` uses only the Python standard library. On builds that ship
 no CA store (e.g. some python.org macOS builds), `pip install certifi` gives it

--- a/dsl_fhe/AGENTS.md
+++ b/dsl_fhe/AGENTS.md
@@ -3,8 +3,9 @@
 > **Building an FHE app? Read the design skill first — do not skip the design
 > stages.** Before you write a single `.niob` file, read
 > [`../.claude/skills/fhe-application-design/SKILL.md`](../.claude/skills/fhe-application-design/SKILL.md).
-> It walks you from problem statement through privacy model, feasibility, scheme
-> selection, circuit design, SIMD data layout, and parameter selection. Copying an
+> It walks you from problem statement through privacy model, feasibility,
+> plaintext ground truth, scheme selection, circuit design, and parameter
+> selection to implementation and protocol spec. Copying an
 > example without doing this design work is the most common way to ship a
 > working-but-wrong FHE application. This file (design rationale + codegen
 > internals) is *reference*, not the starting point.
@@ -26,7 +27,7 @@ make set-membership         # Build the private name-matching example
 
 | File | Purpose |
 |---|---|
-| **`../.claude/skills/fhe-application-design/SKILL.md`** | **START HERE for a new app** — 8-stage design guide (privacy model → feasibility → scheme → circuit → data layout → parameters → codegen). Read before writing `.niob`. |
+| **`../.claude/skills/fhe-application-design/SKILL.md`** | **START HERE for a new app** — 8-stage design guide (privacy model → feasibility → plaintext ground truth → scheme → circuit → parameters → implementation → protocol spec). Read before writing `.niob`. |
 | `AGENTS.md` | This file — design rationale, codegen internals, known pitfalls (imported by `CLAUDE.md`, or read directly by non-Claude agents) |
 | `HOWTO.md` | Step-by-step guide for adding a new example |
 | `NB_LANGUAGE.md` | Language reference — types, syntax, built-in functions, patterns |

--- a/dsl_fhe/CLAUDE.md
+++ b/dsl_fhe/CLAUDE.md
@@ -2,8 +2,9 @@
 
 > **Building an FHE app with this DSL? STOP and read
 > [`../.claude/skills/fhe-application-design/SKILL.md`](../.claude/skills/fhe-application-design/SKILL.md)
-> first.** It is an 8-stage design guide (privacy model → feasibility → scheme →
-> circuit → data layout → parameters → codegen). Do not skip the design stages and
+> first.** It is an 8-stage design guide (privacy model → feasibility → plaintext
+> ground truth → scheme → circuit → parameters → implementation → protocol
+> spec). Do not skip the design stages and
 > jump straight to copying an example — that is the most common way to get a
 > working-but-wrong FHE application.
 


### PR DESCRIPTION
Stacked on #229.

Corrections from a full README-vs-code audit — every snippet was executed against a fresh build:

- **Minimal example**: adds the four OpenFHE serialization headers it needs to compile (`Serial::DeserializeFromFile` on a CryptoContext hits a static_assert without them), and calls `replay()` unconditionally after recording — the old cache-hit-only else-branch failed with `Result 'result' not found` on the recording run (verified empirically)
- **Incremental Build**: `build`/`build-release` require a prior configure, matching AGENTS.md
- `simple_ops` implements 14 ops, not 13
- **Fog**: describes driver mode inline instead of a dangling "(see above)", documents the bare no-app `fog submit` form
- **New**: 'Linking your own application' section — a verified CMake recipe for out-of-tree apps, with the `OPENFHE_CPROBES` trap called out (probes are header-inlined; without the define an app builds and runs but records an incomplete trace that replays garbage)
- **Stage lists**: AGENTS.md, dsl_fhe/AGENTS.md and dsl_fhe/CLAUDE.md summarized the 8-stage design skill incorrectly (omitted plaintext ground truth and protocol spec, invented a standalone SIMD-data-layout stage); aligned with SKILL.md