### PR TITLE
refactor: define the public init() flag surface (--target, --hollow, --opt-level, -v)

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,22 @@ crypto context, tag the eval keys, and tag each input ciphertext as your code
 loads them (this is what the DSL generates). See
 [`docs/AUTO_FACADE.md`](docs/AUTO_FACADE.md).
 
+### `init()` command-line flags
+
+`niobium::compiler().init(argc, argv)` parses and removes these Niobium flags
+from your application's command line; everything else is left in argv for your
+own argument handling:
+
+| Flag | Effect |
+|---|---|
+| `--target=<t>` | Where `replay()` executes. `local` (default) replays in-process on the bundled FHETCH simulator; any other value hands the replay off to the `nbcc_fhetch_replay` transport client (e.g. `FOG` — see entry point 3). |
+| `--hollow` | Hollow recording — capture the instruction trace without computing the real polynomial math (how `examples/bootstrap` keeps its very large trace affordable). |
+| `--opt-level=<O0..O3>` | Optimization level, forwarded with the trace on a non-local replay handoff. |
+| `-v` | Verbose diagnostics. |
+
+Additional internal/testing flags exist and are documented in the parser
+itself (`niobium-fhetch`'s `src/compiler.cpp`).
+
 ### Tagging inputs, keys, and outputs (manual mode)
 
 - `capture_crypto_context(cc)` — stamps the manifest with ring dimension,

--- a/docs/AUTO_FACADE.md
+++ b/docs/AUTO_FACADE.md
@@ -124,23 +124,14 @@ keys:
 compiler:
   target:       local          # local = in-process FHETCH simulator (default);
                                # any other value dispatches replay to nbcc_fhetch_replay
-  optimization: "3"            # -O level
-  registers:    "32"           # --registers
-  memory:       "16"           # --memory (GB)
-  niobium_hw:   true           # --niobium_hw
+  optimization: "3"            # --opt-level (O0..O3), forwarded on replay handoff
+  verbose:      false          # -v
   hollow:       false          # enable_hollow_mode (read directly, not passed to init)
-  fence:        true           # --fence / --no-fence
-  noop:         "0"            # --noop
-  multiplier:   "shoup"        # --multiplier (standard | shoup)
-  config_sectors: "4"          # --config-sectors
-  binary_json:  true           # --binary-json / --ascii-json
-  no_cereal_binary: false      # --no-cereal-binary
-  transform_bin_to_json: false # --transform-bin-to-json
-  no_preserve_input_ciphertexts: false
-  formal:       false          # --formal
-  lock_timing:  false          # --lock-timing
-  no_ring_dim_check: false     # --no-ring-dim-check (needed for toy ring dims)
 ```
+
+Additional internal/testing fields are accepted (see the flag parser in
+`niobium-fhetch`'s `src/compiler.cpp` for the authoritative list); they are
+not part of the public interface.
 
 ### `nbcc.py` Wrapper
 
@@ -153,16 +144,13 @@ python3 tools/nbcc.py --name NAME \
     [--version V] [--description D] \
     [--cache KEY=VALUE ...] \
     [--keys-mult PATH] [--keys-auto PATH] \
-    [--target TARGET] [-O LEVEL] \
-    [--registers N] [--memory GB] \
-    [--niobium-hw] [--hollow] \
-    [--fence | --no-fence] [--no-ring-dim-check] \
+    [--target TARGET] [-O LEVEL] [-v] [--hollow] \
     [--fhetch-driver PATH [--driver-cc PATH] [--driver-ring-dim N] [--driver-output NAME:PATH ...]] \
     -- EXECUTABLE [ARGS...]
 ```
 
-(Run `nbcc.py --help` for the remaining pass-through flags: `--noop`,
-`--multiplier`, `--config-sectors`, `--binary-json`/`--ascii-json`, etc.)
+(`nbcc.py --help` also lists internal/testing pass-through flags — e.g. the
+`--no-ring-dim-check` used below, which the toy ring dimension needs.)
 
 **Behavior:**
 1. Builds a YAML string from the CLI options

--- a/src/auto_facade/AutoFacade.cpp
+++ b/src/auto_facade/AutoFacade.cpp
@@ -258,21 +258,13 @@ static std::vector<std::string> build_init_argv(const YAML::Node &node) {
   };
 
   add_value_flag("target", "--target");
-  if (node["optimization"])
-    args.push_back("-O" + node["optimization"].as<std::string>());
-  add_value_flag("registers", "--registers");
-  add_value_flag("memory", "--memory");
+  // init() parses --opt-level (values O0..O3, with or without the leading O)
+  add_value_flag("optimization", "--opt-level");
+  add_bool_flag("verbose", "-v");
+  // Internal/testing fields (see the flag parser in niobium-fhetch's
+  // src/compiler.cpp). Fields for flags init() does not parse were dropped
+  // with the compiler-repo port.
   add_bool_flag("niobium_hw", "--niobium_hw");
-  add_bool_flag("fence", "--fence", "--no-fence");
-  add_value_flag("noop", "--noop");
-  add_value_flag("multiplier", "--multiplier");
-  add_value_flag("config_sectors", "--config-sectors");
-  add_bool_flag("binary_json", "--binary-json", "--ascii-json");
-  add_bool_flag("no_cereal_binary", "--no-cereal-binary");
-  add_bool_flag("transform_bin_to_json", "--transform-bin-to-json");
-  add_bool_flag("no_preserve_input_ciphertexts", "--no-preserve-input-ciphertexts");
-  add_bool_flag("formal", "--formal");
-  add_bool_flag("lock_timing", "--lock-timing");
   add_bool_flag("no_ring_dim_check", "--no-ring-dim-check");
 
   return args;

--- a/tools/nbcc.py
+++ b/tools/nbcc.py
@@ -58,21 +58,9 @@ def build_yaml(args):
 
     add_value("target", args.target)
     add_value("optimization", args.optimization)
-    add_value("registers", args.registers)
-    add_value("memory", args.memory)
-    add_bool("niobium_hw", args.niobium_hw)
+    add_bool("verbose", args.verbose)
     add_bool("hollow", args.hollow)
-    # fence: --fence sets True, --no-fence sets False, neither sets None
-    add_bool("fence", args.fence)
-    add_value("noop", args.noop)
-    add_value("multiplier", args.multiplier)
-    add_value("config_sectors", args.config_sectors)
-    add_bool("binary_json", args.binary_json)
-    add_bool("no_cereal_binary", args.no_cereal_binary)
-    add_bool("transform_bin_to_json", args.transform_bin_to_json)
-    add_bool("no_preserve_input_ciphertexts", args.no_preserve_input_ciphertexts)
-    add_bool("formal", args.formal)
-    add_bool("lock_timing", args.lock_timing)
+    # Internal/testing flag (needed for toy ring dimensions).
     add_bool("no_ring_dim_check", args.no_ring_dim_check)
 
     if compiler_lines:
@@ -129,39 +117,14 @@ def parse_args():
                         help="Target (default: local — in-process FHETCH sim; "
                              "non-local values dispatch to nbcc_fhetch_replay)")
     parser.add_argument("-O", "--optimization", default=None,
-                        help="Optimization level")
-    parser.add_argument("--registers", default=None, help="Number of registers")
-    parser.add_argument("--memory", default=None, help="Memory in GB")
-    parser.add_argument("--niobium-hw", action="store_true", default=None,
-                        help="Enable niobium hardware mode")
+                        help="Optimization level (O0..O3)")
+    parser.add_argument("-v", "--verbose", action="store_true", default=None,
+                        help="Verbose compiler output")
     parser.add_argument("--hollow", action="store_true", default=None,
                         help="Enable hollow mode")
-
-    # Fence (mutually exclusive)
-    fence_group = parser.add_mutually_exclusive_group()
-    fence_group.add_argument("--fence", action="store_true", dest="fence", default=None)
-    fence_group.add_argument("--no-fence", action="store_false", dest="fence")
-
-    parser.add_argument("--noop", default=None, help="Noop value")
-    parser.add_argument("--multiplier", default=None,
-                        choices=["standard", "shoup"], help="Multiplier type")
-    parser.add_argument("--config-sectors", default=None, help="Config sectors")
-
-    # Binary/JSON (mutually exclusive)
-    json_group = parser.add_mutually_exclusive_group()
-    json_group.add_argument("--binary-json", action="store_true",
-                            dest="binary_json", default=None)
-    json_group.add_argument("--ascii-json", action="store_false",
-                            dest="binary_json")
-
-    parser.add_argument("--no-cereal-binary", action="store_true", default=None)
-    parser.add_argument("--transform-bin-to-json", action="store_true", default=None)
-    parser.add_argument("--no-preserve-input-ciphertexts", action="store_true",
-                        default=None)
-    parser.add_argument("--formal", action="store_true", default=None)
-    parser.add_argument("--lock-timing", action="store_true", default=None)
     parser.add_argument("--no-ring-dim-check", action="store_true", default=None,
-                        help="Skip the Niobium hardware ring-dimension check")
+                        help="Internal/testing: skip the Niobium hardware "
+                             "ring-dimension check (toy ring dimensions)")
 
     # Positional: everything after --
     parser.add_argument("command", nargs=argparse.REMAINDER,


### PR DESCRIPTION
Top of the stack (on #231).

Declares the public `init()` flag set — `--target`, `--hollow`, `--opt-level`, `-v` — and makes docs and tooling consistent with it:

- **nbcc.py**: drops the compiler-repo leftover options (`--registers`, `--memory`, `--fence`, `--noop`, `--multiplier`, `--config-sectors`, `--binary-json`, `--no-cereal-binary`, `--transform-bin-to-json`, `--no-preserve-input-ciphertexts`, `--formal`, `--lock-timing`, `--niobium-hw`) whose emitted flags this client's `init()` never parsed; gains `-v/--verbose`. `--no-ring-dim-check` stays (internal/testing; the toy-ring-dim harness needs it).
- **AutoFacade.cpp**: the YAML `optimization` field now emits `--opt-level` (previously `-O`, which `init()` ignores — the documented field was silently inert); new `verbose` field emits `-v`; dead conversions removed.
- **README**: new '`init()` command-line flags' table in Entry point 2 with the four public flags; internal/testing flags are documented in the parser itself (niobium-fhetch `src/compiler.cpp`, companion PR there).
- **AUTO_FACADE.md**: YAML `compiler:` reference and nbcc synopsis trimmed to the same public set.

**Verified**: `test-auto-ciphers-release` passes; a record+replay run through nbcc.py with `-O 2 -v` works with the flags flowing YAML → `--opt-level=2`/`-v` → parsed by `init()`.