### PR TITLE
increase payload size on client and write timeout on server

### DIFF
--- a/src/fhetch_transport/client.cpp
+++ b/src/fhetch_transport/client.cpp
@@ -160,6 +160,7 @@ int main(int argc, char** argv) {
     cli.set_read_timeout(60 * 120, 0);  // 2 hr — FUNC_SIM_HW on large workloads can exceed 30 min
     cli.set_write_timeout(60, 0);
     cli.set_connection_timeout(10, 0);
+    cli.set_payload_max_length(SIZE_MAX); // increase max payload
 
     httplib::Headers headers = {
         {nft::kTargetHeader,      args.target},

--- a/src/fhetch_transport/server.cpp
+++ b/src/fhetch_transport/server.cpp
@@ -338,6 +338,7 @@ int main(int argc, char** argv) {
     // "Failed to write connection" error.
     srv.set_payload_max_length((std::numeric_limits<size_t>::max)());
     srv.set_read_timeout(60 * 120, 0);  // 2 hr — matches client's read timeout
+    srv.set_write_timeout(60 * 120, 0); // 2 hr - match read/write
     std::signal(SIGINT,  shutdown_handler);
     std::signal(SIGTERM, shutdown_handler);
 


### PR DESCRIPTION
larger downloads were failing due to payload size and timeouts. 