### PR TITLE
dsl: probe + rehydrate save()d outputs of @hardware stages

### DIFF
--- a/dsl_fhe/AGENTS.md
+++ b/dsl_fhe/AGENTS.md
@@ -274,7 +274,14 @@ Each `@stage("name")` function generates a `.cpp` with:
    `start()` emitted inside it, after the leading input `load()`s so the hooks
    tag inputs first), then `probe()`/`stop()`; on a **cache-valid** run zero FHE
    ops execute — `replay()` runs the cached trace and `result()` reconstructs
-   the output (mirrors the canonical fetch-by-similarity client integration)
+   the output (mirrors the canonical fetch-by-similarity client integration).
+   This covers `save()`d outputs too: each `save()` in an `@hardware` stage
+   also emits a `probe()` (name = the `.bin` filename's stem, or the field
+   name for multi-field wires), and the replay branch reconstructs each file
+   via `result()` — the stage body never runs on a cache-valid run, so
+   without this the saved files would replay stale/empty. Save paths must
+   end in a literal filename and be re-evaluable from `main()` (stage args +
+   consts); violations raise `CodegenError`.
 6. **Result serialization** — always: OpenFHE's own output on a record run,
    the reconstructed ciphertext on a replay run
 
@@ -436,6 +443,31 @@ consumer dirs now match on both hand-offs. Key/context wires are unaffected (can
 cc/pk/mk/rk layout), an explicit `to:` path still overrides, and single-dir (`encdir`)
 designs are unchanged since the `ctxtupdir` branch is gated on that helper existing.
 Pinned by `test_client_output_routes_to_upload_dir`.
+
+### 12. `save()`d Outputs of `@hardware` Stages Replayed Stale/Empty
+
+**Problem**: `save()` in an `@hardware` stage emitted a bare
+`Serial::SerializeToFile` with no `probe()`. In cooperative auto-tagging mode
+the auto-facade's serialize hook doesn't probe either (it gates on the
+facade-driven `g_recording`, which cooperative mode never sets), so the saved
+ciphertext was not a live-out of the FHETCH trace. On a cache-valid run the
+stage body never executes, and the replay branch only rehydrated the returned
+wire result — so `save()` files were left stale from the record run (hollow
+garbage under `--hollow`, or missing entirely), decrypting to zeros/empty.
+Found via furever-home, whose scoring stage returns nothing and `save()`s both
+outputs; its `build_dsl.sh` post-patched the generated code to the manual
+Entry-Point-2 pattern as a workaround. (The other half of that report —
+host-built plaintexts needing manual `tag_input` — was wrong: the
+`on_make_plaintext` hook tags them automatically in cooperative mode.)
+
+**Fix**: `_gen_save()` now also emits `niobium::compiler().probe(<stem>, ct)`
+inside `@hardware` stage bodies (record pass only, since that's the only time
+the body runs), and `_gen_main_body_after_args()`'s replay branch reconstructs
+each registered save site via `result()` + `SerializeToFile` to the same path.
+Probe names come from the save filename's stem (field names for multi-field
+wires); duplicate stems and paths not re-evaluable from `main()` raise
+`CodegenError`. Pinned by `test_hardware_save_probe_and_rehydrate`,
+`test_hardware_save_duplicate_stem_rejected`, `test_client_save_has_no_probe`.
 
 ## File Structure
 

--- a/dsl_fhe/xcomp/codegen.py
+++ b/dsl_fhe/xcomp/codegen.py
@@ -103,6 +103,11 @@ class StageInfo:
     io_specs: list[ast.IoSpec] = field(default_factory=list)
 
 
+class CodegenError(Exception):
+    """A construct the codegen cannot translate correctly (as opposed to a
+    semantic error in the .niob source, which analyze() reports)."""
+
+
 class CodeGenerator:
     """Generates OpenFHE C++ from a checked nb AST."""
 
@@ -141,6 +146,14 @@ class CodeGenerator:
         # {field}.ref.bin raw-double files). Set only while emitting
         # <stage>_ref.cpp translation units.
         self._plain_mode: bool = False
+        self._current_stage_hardware: bool = False
+        # save() sites inside the current @hardware stage body. A cache-valid
+        # run executes zero FHE ops (the stage function is never called), so
+        # every save()d ciphertext must be probe()d during recording and
+        # reconstructed by main()'s replay branch via result(). Entries:
+        # {"stem": probe name, "path": C++ path expr, "field": optional
+        #  "{field}.bin" suffix for multi-field dir saves}.
+        self._hw_stage_saves: list[dict] = []
         self._classify_items()
         # User-function signatures: name -> FnDecl. Lets encrypted-ness (and
         # vector-ness) of user-fn calls resolve from declared return types
@@ -1006,6 +1019,7 @@ endforeach()
         # each input load() (see _gen_let_stmt).
         self._current_fn = stage.fn
         self._current_stage_hardware = bool(stage.hardware)
+        self._hw_stage_saves = []
         self._local_var_cpp_types.clear()
         self._declared_vars.clear()
         self._enc_vars.clear()
@@ -1314,6 +1328,31 @@ endforeach()
             self.wl("}")
             if has_return:
                 self._gen_result_io(stage, "rehydrate")
+            # Reconstruct every save()d output: the stage body never runs on a
+            # cache-valid run, so each recorded probe is fetched via result()
+            # and written to the same file the record pass saved it to.
+            for sv in self._hw_stage_saves:
+                self.wl("{")
+                self.indent()
+                self.wl("Ciphertext<DCRTPoly> _hw_ct;")
+                self.wl(f'if (!niobium::compiler().result(cc, "{sv["stem"]}", _hw_ct)) {{')
+                self.indent()
+                self.wl(f'std::cerr << "[ERROR] Result retrieval failed for '
+                        f'\'{sv["stem"]}\'!" << std::endl;')
+                self.wl("return 1;")
+                self.dedent()
+                self.wl("}")
+                if sv["field"]:
+                    self.wl(f"auto _dir = fs::path({sv['path']});")
+                    self.wl("fs::create_directories(_dir);")
+                    self.wl(f'Serial::SerializeToFile(_dir / "{sv["field"]}", '
+                            f"_hw_ct, SerType::BINARY);")
+                else:
+                    self.wl(f"auto _dir = fs::path({sv['path']});")
+                    self.wl("fs::create_directories(_dir.parent_path());")
+                    self.wl("Serial::SerializeToFile(_dir, _hw_ct, SerType::BINARY);")
+                self.dedent()
+                self.wl("}")
             self.dedent()
             self.wl("}")
         else:
@@ -3350,14 +3389,72 @@ endforeach()
                 f"results.push_back(ct); "
                 f"}} return results; }}()")
 
+    def _hw_save_stem(self, to_ast) -> str | None:
+        """Static probe name for a save() destination: the .bin filename's stem
+        when the path expression ends in a string literal (`dir / "name.bin"`
+        or a bare "name.bin"). None when no literal filename is derivable."""
+        node = to_ast
+        while isinstance(node, ast.BinaryExpr) and node.op == "/":
+            node = node.right
+        if isinstance(node, ast.StringLiteral) and node.value:
+            stem = node.value.rsplit("/", 1)[-1]
+            if "." in stem:
+                stem = stem[:stem.rindex(".")]
+            return stem or None
+        return None
+
+    def _register_hw_save(self, stem: str, path_cpp: str, to_ast,
+                          field: str | None = None):
+        """Record a @hardware save() site for main()'s replay-branch
+        rehydration, validating that the probe name is unique and that the
+        path expression is re-evaluable from main() (stage args + consts)."""
+        taken = {s["stem"] for s in self._hw_stage_saves} | {"result"}
+        if stem in taken:
+            raise CodegenError(
+                f"@hardware stage '{self._current_fn.name}': save() probe name "
+                f"'{stem}' is not unique (each save() needs a distinct .bin "
+                f"filename, and 'result' is reserved for the wire result)")
+        allowed = {p.name for p in self._current_fn.params} | {"inst"}
+        allowed |= {c.name for c in self.consts}
+        callees = {n.func.name for n in self._walk_ast(to_ast)
+                   if isinstance(n, ast.CallExpr) and isinstance(n.func, ast.Ident)}
+        unknown = {n.name for n in self._walk_ast(to_ast)
+                   if isinstance(n, ast.Ident)} - allowed - callees
+        if unknown:
+            raise CodegenError(
+                f"@hardware stage '{self._current_fn.name}': save() path uses "
+                f"stage-local variable(s) {sorted(unknown)} — the path must be "
+                f"computable in main() on a cache-valid run (stage args and "
+                f"consts only), or return the value via the wire result instead")
+        self._hw_stage_saves.append({"stem": stem, "path": path_cpp,
+                                     "field": field})
+
     def _gen_save(self, args: list[ast.Arg]) -> str:
-        """Generate serialization for wire types: save(WireType{...}, to: path)."""
+        """Generate serialization for wire types: save(WireType{...}, to: path).
+
+        Inside an @hardware stage (record pass only — a cache-valid run never
+        executes the stage body), each saved ciphertext is also probe()d so it
+        becomes a live-out of the FHETCH trace; main()'s replay branch then
+        reconstructs the same files via result()."""
         positional = [a for a in args if not a.name]
         named = {a.name: self._expr_to_cpp(a.value) for a in args if a.name}
         to_path = named.get("to", "")
         if not to_path:
             return f"/* save: missing 'to:' argument */"
         data_expr = self._expr_to_cpp(positional[0].value) if positional else "data"
+
+        to_ast = next((a.value for a in args if a.name == "to"), None)
+        hw = self._current_stage_hardware and not self._plain_mode
+
+        def hw_stem_or_raise() -> str:
+            stem = self._hw_save_stem(to_ast)
+            if stem is None:
+                raise CodegenError(
+                    f"@hardware stage '{self._current_fn.name}': cannot derive "
+                    f"a probe name from the save() path — end the 'to:' path "
+                    f"with a literal filename (e.g. dir / \"out.bin\"), or "
+                    f"return the value via the wire result instead")
+            return stem
 
         # Determine wire type from the first positional argument
         type_name = None
@@ -3379,11 +3476,34 @@ endforeach()
                         return (f"nb_plain::write_slots("
                                 f'fs::path({to_path}).string() + ".ref", '
                                 f"{data_expr}.{field})")
+                    if hw:
+                        stem = hw_stem_or_raise()
+                        self._register_hw_save(stem, to_path, to_ast)
+                        return (f"[&]() {{ auto _dir = {to_path}; "
+                                f"fs::create_directories(_dir.parent_path()); "
+                                f"auto&& _w = {data_expr}; "
+                                f"Serial::SerializeToFile(_dir, _w.{field}, SerType::BINARY); "
+                                f'niobium::compiler().probe("{stem}", _w.{field}); }}()')
                     return (f"[&]() {{ auto _dir = {to_path}; "
                             f"fs::create_directories(_dir.parent_path()); "
                             f"Serial::SerializeToFile(_dir, {data_expr}.{field}, SerType::BINARY); }}()")
                 if len(ct_fields) > 1:
                     # Multi-field enc wire type — save each field to {dir}/{field_name}.bin
+                    if hw:
+                        for f in ct_fields:
+                            self._register_hw_save(f.name, to_path, to_ast,
+                                                   field=f"{f.name}.bin")
+                        parts = [f"[&]() {{ auto _dir = fs::path({to_path}); "
+                                 f"fs::create_directories(_dir); "
+                                 f"auto&& _w = {data_expr}; "]
+                        for f in ct_fields:
+                            parts.append(
+                                f'Serial::SerializeToFile(_dir / "{f.name}.bin", '
+                                f"_w.{f.name}, SerType::BINARY); ")
+                            parts.append(
+                                f'niobium::compiler().probe("{f.name}", _w.{f.name}); ')
+                        parts.append("}()")
+                        return "".join(parts)
                     parts = [f"[&]() {{ auto _dir = fs::path({to_path}); "
                              f"fs::create_directories(_dir); "]
                     for f in ct_fields:
@@ -3392,6 +3512,12 @@ endforeach()
                             f"{data_expr}.{f.name}, SerType::BINARY); ")
                     parts.append("}()")
                     return "".join(parts)
+        if hw and positional and self._is_encrypted_expr(positional[0].value):
+            stem = hw_stem_or_raise()
+            self._register_hw_save(stem, to_path, to_ast)
+            return (f"[&]() {{ auto&& _ct = {data_expr}; "
+                    f"Serial::SerializeToFile({to_path}, _ct, SerType::BINARY); "
+                    f'niobium::compiler().probe("{stem}", _ct); }}()')
         return f"Serial::SerializeToFile({to_path}, {data_expr}, SerType::BINARY)"
 
     def _gen_save_secret_key(self, args: list[ast.Arg]) -> str:

--- a/dsl_fhe/xcomp/codegen.py
+++ b/dsl_fhe/xcomp/codegen.py
@@ -147,6 +147,7 @@ class CodeGenerator:
         # <stage>_ref.cpp translation units.
         self._plain_mode: bool = False
         self._current_stage_hardware: bool = False
+        self._current_stage_domain: Domain | None = None
         # save() sites inside the current @hardware stage body. A cache-valid
         # run executes zero FHE ops (the stage function is never called), so
         # every save()d ciphertext must be probe()d during recording and
@@ -1019,6 +1020,7 @@ endforeach()
         # each input load() (see _gen_let_stmt).
         self._current_fn = stage.fn
         self._current_stage_hardware = bool(stage.hardware)
+        self._current_stage_domain = stage.domain
         self._hw_stage_saves = []
         self._local_var_cpp_types.clear()
         self._declared_vars.clear()
@@ -3408,6 +3410,11 @@ endforeach()
         """Record a @hardware save() site for main()'s replay-branch
         rehydration, validating that the probe name is unique and that the
         path expression is re-evaluable from main() (stage args + consts)."""
+        if self._current_stage_domain != Domain.SERVER:
+            raise CodegenError(
+                f"@hardware stage '{self._current_fn.name}': save() replay "
+                f"reconstruction needs the CryptoContext, which main() only "
+                f"loads for @server stages — mark the stage @server")
         taken = {s["stem"] for s in self._hw_stage_saves} | {"result"}
         if stem in taken:
             raise CodegenError(
@@ -3468,8 +3475,7 @@ endforeach()
             wire_def = next((w for w in self.wires if w.name == type_name), None)
             if wire_def:
                 ct_fields = [f for f in wire_def.fields
-                             if (f.type_ann and isinstance(f.type_ann, ast.EncType))
-                             or f.name in ("ciphertext", "score", "query", "result")]
+                             if self._field_kind(f) == "enc"]
                 if len(ct_fields) == 1:
                     field = ct_fields[0].name
                     if self._plain_mode:

--- a/dsl_fhe/xcomp/tests/test_codegen.py
+++ b/dsl_fhe/xcomp/tests/test_codegen.py
@@ -532,6 +532,70 @@ def test_norelin_operator():
     assert "EvalMultNoRelin" in impl
 
 
+def test_hardware_save_probe_and_rehydrate():
+    """save() inside an @hardware stage must probe each output during the
+    record pass and reconstruct it via result() in main()'s replay branch —
+    the stage body never runs on a cache-valid run, so without this the
+    saved files replay as stale/empty (furever-home bug)."""
+    files = compile_str("""
+    struct Instance { ring_dim: u32 }
+    wire EncOut { ciphertext: enc<f64> }
+    fn outdir(inst: Instance) -> path { "io" / "out" }
+    @server @stage(name: "compute") @hardware(cache_key: ["wl"])
+    fn compute(inst: Instance) {
+        let ct: enc<f64> = zero()
+        save(EncOut { ciphertext: ct }, to: outdir(inst) / "first_output.bin")
+        save(EncOut { ciphertext: ct }, to: outdir(inst) / "second_output.bin")
+    }
+    """)
+    cpp = files["compute.cpp"]
+    # Record pass: each save() also probes, making the ct a trace live-out.
+    # The probe name is the save() filename's stem — nothing is hardcoded.
+    assert 'niobium::compiler().probe("first_output"' in cpp
+    assert 'niobium::compiler().probe("second_output"' in cpp
+    # Replay branch: each save() site is rehydrated via result() and
+    # re-serialized to the same path.
+    replay_branch = cpp.split("} else {")[1]
+    assert 'result(cc, "first_output"' in replay_branch
+    assert 'result(cc, "second_output"' in replay_branch
+    assert replay_branch.count("SerializeToFile") >= 2
+
+
+def test_hardware_save_duplicate_stem_rejected():
+    from xcomp.codegen import CodegenError
+    try:
+        compile_str("""
+        struct Instance { ring_dim: u32 }
+        wire EncOut { ciphertext: enc<f64> }
+        fn encdir(inst: Instance) -> path { "io" / "encrypted" }
+        @server @stage(name: "compute") @hardware(cache_key: ["wl"])
+        fn compute(inst: Instance) {
+            let ct: enc<f64> = zero()
+            save(EncOut { ciphertext: ct }, to: encdir(inst) / "out.bin")
+            save(EncOut { ciphertext: ct }, to: encdir(inst) / "sub" / "out.bin")
+        }
+        """)
+        assert False, "expected CodegenError for duplicate save() stem"
+    except CodegenError as e:
+        assert "not unique" in str(e)
+
+
+def test_client_save_has_no_probe():
+    """Only @hardware stages probe their save()s — client stages and
+    non-hardware servers keep the plain serialization."""
+    files = compile_str("""
+    struct Instance { ring_dim: u32 }
+    wire EncOut { ciphertext: enc<f64> }
+    fn encdir(inst: Instance) -> path { "io" / "encrypted" }
+    @client @stage(name: "enc")
+    fn enc_stage(inst: Instance) {
+        let ct: enc<f64> = zero()
+        save(EncOut { ciphertext: ct }, to: encdir(inst) / "input.bin")
+    }
+    """)
+    assert "probe(" not in files["enc.cpp"]
+
+
 def test_closure_generation():
     files = compile_str("""
     fn f() {

--- a/dsl_fhe/xcomp/tests/test_codegen.py
+++ b/dsl_fhe/xcomp/tests/test_codegen.py
@@ -580,6 +580,44 @@ def test_hardware_save_duplicate_stem_rejected():
         assert "not unique" in str(e)
 
 
+def test_save_field_detection_is_structural():
+    """A plain field is never treated as a ciphertext by save(), regardless
+    of its name — detection is _field_kind()-structural, with no name
+    fallback. A plain-named-'result' wire in an @hardware stage must not be
+    probed (it can't be a trace live-out)."""
+    files = compile_str("""
+    struct Instance { ring_dim: u32 }
+    wire Meta { result: f64 }
+    fn outdir(inst: Instance) -> path { "io" / "out" }
+    @server @stage(name: "compute") @hardware(cache_key: ["wl"])
+    fn compute(inst: Instance) {
+        save(Meta { result: 1.0 }, to: outdir(inst) / "meta.bin")
+    }
+    """)
+    cpp = files["compute.cpp"]
+    assert "probe(" not in cpp
+    # Falls through to whole-struct serialization, not a .result field access.
+    assert ".result, SerType::BINARY" not in cpp
+
+
+def test_hardware_save_requires_server_stage():
+    from xcomp.codegen import CodegenError
+    try:
+        compile_str("""
+        struct Instance { ring_dim: u32 }
+        wire EncOut { ciphertext: enc<f64> }
+        fn outdir(inst: Instance) -> path { "io" / "out" }
+        @client @stage(name: "cl") @hardware(cache_key: ["wl"])
+        fn cl(inst: Instance) {
+            let ct: enc<f64> = zero()
+            save(EncOut { ciphertext: ct }, to: outdir(inst) / "out.bin")
+        }
+        """)
+        assert False, "expected CodegenError for @client @hardware save()"
+    except CodegenError as e:
+        assert "@server" in str(e)
+
+
 def test_client_save_has_no_probe():
     """Only @hardware stages probe their save()s — client stages and
     non-hardware servers keep the plain serialization."""


### PR DESCRIPTION
## Problem

`save()` inside an `@hardware` stage emitted a bare `SerializeToFile` with no `probe()`. In cooperative auto-tagging mode the auto-facade's serialize hook doesn't probe either (it gates on the facade-driven `g_recording`, which cooperative mode never sets), so the saved ciphertext was never a live-out of the FHETCH trace. Since the stage body doesn't run on a cache-valid run, the replay branch left `save()` files stale from the record pass — hollow garbage under `--hollow`, or missing entirely — decrypting to zeros/empty.

Found via [furever-home](https://github.com/sw-zzz/furever-home), whose scoring stage returns nothing and `save()`s both outputs; its `build_dsl.sh` had to post-patch the generated code into the manual Entry-Point-2 pattern as a workaround.

## Fix

- `_gen_save()` also emits `probe(<stem>, ct)` inside `@hardware` stage bodies — stem = the save filename's stem (field names for multi-field wires), matching the file-stem convention the auto-facade uses elsewhere.
- `main()`'s replay branch reconstructs each save site via `result()` + `SerializeToFile` to the same path expression re-emitted from the `.niob`.
- New `CodegenError` rejects duplicate probe stems, paths without a literal filename, and paths using stage-local variables (not re-evaluable in `main()`), with guidance to return via the wire result instead.

## Validation

- Output is **byte-identical across all seven shipped examples** (none `save()` from `@hardware`, which is why tests never caught this).
- End-to-end on furever-home with stock codegen output: record → delete both output files → cooperative local replay via `fhetch_driver` → decrypt matches the plaintext reference exactly. Before the fix the same sequence failed with `no probe names in ...outputs.json` → `Decrypt(): ciphertext is empty`.
- The other half of the original report — host-built plaintexts needing manual `tag_input` — was a misdiagnosis: the `on_make_plaintext` hook already tags them in cooperative mode (verified by removing furever's manual tag and replaying correctly).
- Pinned by `test_hardware_save_probe_and_rehydrate`, `test_hardware_save_duplicate_stem_rejected`, `test_client_save_has_no_probe` (35/35 pass); documented as pitfall 12 in `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)