### PR TITLE
codegen: rehydrate vec<enc> results on replay instead of iterating an…

### DIFF
--- a/dsl_fhe/xcomp/codegen.py
+++ b/dsl_fhe/xcomp/codegen.py
@@ -1770,25 +1770,59 @@ endforeach()
                 self._emit_ct_io(action, f'"{base}"', f"result.{f.name}")
             elif (ann and isinstance(ann, ast.VecType) and ann.elem
                   and isinstance(ann.elem, ast.EncType)):
-                self.wl(f"for (size_t _i = 0; _i < result.{f.name}.size(); ++_i) {{")
-                self.indent()
-                self._emit_ct_io(action,
-                                 f'"{base}_" + std::to_string(_i)',
-                                 f"result.{f.name}[_i]")
-                self.dedent()
-                self.wl("}")
+                if action == "probe":
+                    self.wl(f"for (size_t _i = 0; _i < result.{f.name}.size(); ++_i) {{")
+                    self.indent()
+                    self._emit_ct_io(action,
+                                     f'"{base}_" + std::to_string(_i)',
+                                     f"result.{f.name}[_i]")
+                    self.dedent()
+                    self.wl("}")
+                else:
+                    # Replay branch: the stage body never ran, so result.{f.name}
+                    # is an empty vector — a .size()-driven loop would rehydrate
+                    # nothing (only scalar fields would round-trip, and the
+                    # per-element .bin files would never be written). Grow the
+                    # vector by rehydrating result_<field>_<i> until a probe is
+                    # absent (result() returns false, printing one benign
+                    # "not found" line, at index == count).
+                    self.wl(f"for (size_t _i = 0; ; ++_i) {{")
+                    self.indent()
+                    self.wl("Ciphertext<DCRTPoly> _rehydrated;")
+                    self.wl(f'if (!niobium::compiler().result(cc, "{base}_" + std::to_string(_i), _rehydrated)) break;')
+                    self.wl(f"result.{f.name}.push_back(_rehydrated);")
+                    self.dedent()
+                    self.wl("}")
             elif (ann and isinstance(ann, ast.VecType) and ann.elem
                   and isinstance(ann.elem, ast.VecType)
                   and ann.elem.elem and isinstance(ann.elem.elem, ast.EncType)):
                 # vec<vec<enc>> — e.g. EncryptedDB rows/payloads
-                self.wl(f"for (size_t _b = 0; _b < result.{f.name}.size(); ++_b)")
-                self.wl(f"for (size_t _i = 0; _i < result.{f.name}[_b].size(); ++_i) {{")
-                self.indent()
-                self._emit_ct_io(action,
-                                 f'"{base}_" + std::to_string(_b) + "_" + std::to_string(_i)',
-                                 f"result.{f.name}[_b][_i]")
-                self.dedent()
-                self.wl("}")
+                if action == "probe":
+                    self.wl(f"for (size_t _b = 0; _b < result.{f.name}.size(); ++_b)")
+                    self.wl(f"for (size_t _i = 0; _i < result.{f.name}[_b].size(); ++_i) {{")
+                    self.indent()
+                    self._emit_ct_io(action,
+                                     f'"{base}_" + std::to_string(_b) + "_" + std::to_string(_i)',
+                                     f"result.{f.name}[_b][_i]")
+                    self.dedent()
+                    self.wl("}")
+                else:
+                    # Replay branch: grow both dimensions until probes run out
+                    # (see the vec<enc> case above for why .size() can't drive it).
+                    self.wl(f"for (size_t _b = 0; ; ++_b) {{")
+                    self.indent()
+                    self.wl("std::vector<Ciphertext<DCRTPoly>> _row;")
+                    self.wl(f"for (size_t _i = 0; ; ++_i) {{")
+                    self.indent()
+                    self.wl("Ciphertext<DCRTPoly> _rehydrated;")
+                    self.wl(f'if (!niobium::compiler().result(cc, "{base}_" + std::to_string(_b) + "_" + std::to_string(_i), _rehydrated)) break;')
+                    self.wl("_row.push_back(_rehydrated);")
+                    self.dedent()
+                    self.wl("}")
+                    self.wl("if (_row.empty()) break;")
+                    self.wl(f"result.{f.name}.push_back(_row);")
+                    self.dedent()
+                    self.wl("}")
 
     def _emit_ct_io(self, action: str, name_expr: str, lvalue: str):
         if action == "probe":


### PR DESCRIPTION
… empty vector

_emit_wire_ct_io emits both the probe() calls (record) and the result() calls (replay) from one loop header, so the replay branch inherited a `_i < result.<field>.size()` bound. On replay the stage body never runs, so the local wire struct is default-constructed and every vec<enc> / vec<vec<enc>> field has size 0 — the loop body executes zero times.

Only scalar enc fields round-tripped. The failure was silent: zero iterations is indistinguishable from success, the function returns 0, and because the serialization loop below is driven by the same empty vectors, stale per-element .bin files from the previous record run stay on disk and decrypt into plausible-looking values.

Make the iteration direction-dependent: on replay, grow the vector by rehydrating result_<field>_<i> until result() reports a probe absent. Probe-name generation stays shared between the two directions, so names still match exactly across record and replay. vec<vec<enc>> (EncryptedDB rows/payloads) grows both dimensions the same way.

Verified on the VitalVault example (CKKS ring 2048, depth 20) over the FHETCH transport against a FUNC_SIM replay backend: all 59 probes now rehydrate (8 system_scores + bioage_delta + 25 contributions + 25 followups), all 59 result files are rewritten, and the decrypted report matches the cleartext reference twin within CKKS noise (panel scores within 0.019, bioage_delta -1.4619 vs -1.46). Before the fix only bioage_delta was retrieved.