### PR TITLE
Harden nbcc_fhetch_replay_server input handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -595,8 +595,32 @@ test-fhetch-release: $(OPENFHE_BUILD_DEP_RELEASE) ## Run the fhetch submodule's 
 # Override AUTO_OP=MUL AUTO_EXPECTED=21 to exercise the known-failing
 # relin path inside the auto-facade test.
 
+# ==============================================================================
+# test-transport-hardening-release — input-validation regressions for the daemon
+#
+# Drives nbcc_fhetch_replay_server with hostile input (X-Target traversal, shell
+# metacharacters in archive entry names, absurd length fields) and asserts the
+# refusals fire. Complements test-mult-transport-release, which only proves the
+# happy path.
+#
+# Needs no compiler: every case is refused before the server spawns anything, so
+# the script supplies a stub --exec. Pass PROJECT=<dir> together with a real
+# compiler to additionally verify the per-job timing dir:
+#
+#   make test-transport-hardening-release \
+#        COMPILER_BIN=$(NIOBIUM_COMPILER_ROOT)/build/nbcc_fhetch_replay \
+#        PROJECT=mult_server_workload_ckks_mult
+# ==============================================================================
+
+test-transport-hardening-release: build-release ## Security regressions for the transport server (no compiler needed)
+	$(call set-build-config,Release,build)
+	@$(PYTHON) scripts/test_transport_hardening.py \
+	    --server-bin build/src/fhetch_transport/nbcc_fhetch_replay_server \
+	    $(if $(COMPILER_BIN),--exec $(COMPILER_BIN),) \
+	    $(if $(PROJECT),--project $(PROJECT),)
+
 ## Run all client-level Release tests (CI target — no fhetch submodule)
-test-client-release: test-simple-ops-release test-mult-release test-auto-ciphers-release test-bootstrap-release test-plaintext-add-release test-ring-dim-check-release
+test-client-release: test-simple-ops-release test-mult-release test-auto-ciphers-release test-bootstrap-release test-plaintext-add-release test-ring-dim-check-release test-transport-hardening-release
 
 ## Run all currently-passing Release tests (client + fhetch submodule) — internal server only, do not run in CI
 test-release: test-client-release test-fhetch-release

--- a/scripts/test_transport_hardening.py
+++ b/scripts/test_transport_hardening.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Security regression tests for nbcc_fhetch_replay_server.
+
+The transport's end-to-end test (test_transport_mult.sh) proves the happy path
+works. It cannot prove that anything gets *rejected*, which is what the server's
+input validation exists for. This suite drives the daemon over HTTP with hostile
+input and asserts the refusals actually fire:
+
+  1. X-Target path traversal          — the target becomes a path component
+                                        (devices/<target>/spec.yaml) on the
+                                        compiler side, so ".." must not survive
+  2. Legitimate device ids            — the guard must not reject real targets
+                                        (fpga6.1.0 and func_sim_hw are the ones
+                                        a naive charset rule breaks)
+  3. Hostile archive entry names      — the archive format stores names
+                                        verbatim; shell metacharacters and
+                                        traversal must never reach the filesystem
+  4. Implausible name lengths         — rejected before being buffered
+  5. Error bodies withhold paths      — no server-side path disclosure unless
+                                        the operator passes --return-logs
+  6. Per-job timing dir (optional)    — NB_TIMING_SUMMARY_DIR still reaches the
+                                        compiler; needs a real compiler binary
+
+Cases 1-5 need no compiler: every one of them is refused before the server
+spawns anything, so a stub --exec is enough and this runs in the client's own
+CI. Case 6 needs the real (proprietary) nbcc_fhetch_replay plus a recorded
+project, so it only runs when --project and --exec point at them.
+
+Usage:
+  test_transport_hardening.py [--server-bin PATH] [--exec PATH] [--project DIR]
+"""
+import argparse
+import os
+import pathlib
+import socket
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+
+CLIENT_ROOT = pathlib.Path(__file__).resolve().parent.parent
+DEFAULT_SERVER = CLIENT_ROOT / "build/src/fhetch_transport/nbcc_fhetch_replay_server"
+
+
+class Results:
+    def __init__(self):
+        self.failures = []
+
+    def check(self, name, ok, detail=""):
+        print(f"  {'PASS' if ok else 'FAIL'}  {name}", flush=True)
+        if not ok:
+            self.failures.append(f"{name}: {detail}")
+            if detail:
+                print(f"        {detail}", flush=True)
+
+
+def free_port():
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def archive(entries):
+    """Build an NBAR archive: magic, u32 count, then per entry
+    u32 name_len + name + u64 data_len + data."""
+    out = b"NBAR" + struct.pack("<I", len(entries))
+    for name, data in entries:
+        raw = name.encode()
+        out += struct.pack("<I", len(raw)) + raw
+        out += struct.pack("<Q", len(data)) + data
+    return out
+
+
+def pack_dir(root):
+    root = pathlib.Path(root)
+    files = sorted(p for p in root.rglob("*") if p.is_file())
+    return archive([(p.relative_to(root).as_posix(), p.read_bytes()) for p in files])
+
+
+def post(base, body, target="FUNC_SIM", job_id=None, timeout=60):
+    headers = {"X-Target": target, "Content-Type": "application/x-niobium-archive"}
+    if job_id:
+        headers["X-Job-Id"] = job_id
+    req = urllib.request.Request(f"{base}/replay", data=body, method="POST",
+                                 headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+
+
+def wait_healthy(base, proc, attempts=30):
+    for _ in range(attempts):
+        if proc.poll() is not None:
+            return False
+        try:
+            with urllib.request.urlopen(f"{base}/healthz", timeout=2) as resp:
+                if resp.status == 200:
+                    return True
+        except (urllib.error.URLError, OSError):
+            pass
+        time.sleep(1)  # sleep between polls: never spin on a socket/file
+    return False
+
+
+def run_checks(base, res, project, real_compiler, timing_root):
+    good = archive([("fhetch_replay.json", b"{}")])
+
+    print("[1] X-Target traversal rejected")
+    for bad in ["../../../etc", "..", "a/../../b", "func_sim/../../x",
+                ".hidden", "fpga5.2/", "a b", "x;y", "$(id)"]:
+        status, body = post(base, good, target=bad)
+        text = body.decode(errors="replace")
+        res.check(f"target {bad!r} -> 400",
+                  status == 400 and "X-Target" in text,
+                  f"got {status}: {text[:120]!r}")
+
+    print("[2] Legitimate device ids pass target validation")
+    for ok in ["FUNC_SIM", "func_sim", "func_sim_hw", "fpga5.2", "fpga6.1.0",
+               "fpga8.0.1", "mistic1.0", "qemu_sim", "FOG"]:
+        status, body = post(base, good, target=ok)
+        text = body.decode(errors="replace")
+        # Must get PAST the target check; failing later (unpack/compile) is fine.
+        res.check(f"target {ok!r} accepted", "X-Target" not in text,
+                  f"rejected by target check: {status}: {text[:120]!r}")
+
+    print("[3] Hostile archive entry names rejected")
+    hostile = {
+        "shell metachar":   "out;rm -rf ~.ct",
+        "cmd substitution": "$(whoami).ct",
+        "backtick":         "`id`.ct",
+        "space":            "two words.ct",
+        "leading dash":     "-rf.ct",
+        "traversal":        "../escaped.ct",
+        "nested traversal": "a/../../escaped.ct",
+        "absolute path":    "/etc/passwd",
+        "newline":          "probe\n.ct",
+        "backslash":        "a\\b.ct",
+        "quote":            'a"b.ct',
+    }
+    for label, name in hostile.items():
+        status, body = post(base, archive([(name, b"x")]))
+        res.check(f"{label} ({name!r}) -> 400", status == 400,
+                  f"got {status}: {body.decode(errors='replace')[:120]!r}")
+
+    print("[4] Implausible entry name length rejected")
+    status, body = post(base, b"NBAR" + struct.pack("<I", 1)
+                        + struct.pack("<I", 0xFFFFFFFF))
+    res.check("name_len=4G -> 400", status == 400,
+              f"got {status}: {body.decode(errors='replace')[:120]!r}")
+
+    print("[5] Error bodies withhold server-side paths")
+    leaks = []
+    for name in ["../escaped.ct", "out;rm.ct"]:
+        _, body = post(base, archive([(name, b"x")]))
+        text = body.decode(errors="replace")
+        for marker in ("/var/folders", "/tmp/", "nbcc_fhetch_server_"):
+            if marker in text:
+                leaks.append(f"{name!r} leaked {marker!r}")
+    res.check("no temp path in error bodies", not leaks, "; ".join(leaks))
+
+    if not (project and real_compiler):
+        print("[6] Per-job timing dir: SKIPPED (needs --project and a real --exec)")
+        return
+
+    print("[6] Per-job timing dir reaches the compiler")
+    job = "job-hardening-test"
+    status, body = post(base, pack_dir(project), job_id=job, timeout=900)
+    res.check("replay with X-Job-Id -> 200", status == 200,
+              f"got {status}: {body.decode(errors='replace')[:200]!r}")
+    if status == 200:
+        job_dir = pathlib.Path(timing_root) / job
+        produced = sorted(p.name for p in job_dir.rglob("*")) if job_dir.is_dir() else []
+        # Telemetry can only land here if the child actually got the env var.
+        res.check("NB_TIMING_SUMMARY_DIR honored", bool(produced),
+                  f"{job_dir} empty or missing")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--server-bin", default=str(DEFAULT_SERVER))
+    ap.add_argument("--exec", dest="compiler",
+                    help="compiler binary; omit to use a stub (cases 1-5 only)")
+    ap.add_argument("--project", help="recorded fhetch project dir (enables case 6)")
+    args = ap.parse_args()
+
+    if not os.access(args.server_bin, os.X_OK):
+        sys.exit(f"error: server binary not executable: {args.server_bin}\n"
+                 f"build it with: make build-release")
+
+    # Cases 1-5 never reach the compiler, so any executable satisfies the
+    # server's startup pre-flight. Case 6 needs the real thing.
+    real_compiler = bool(args.compiler)
+    compiler = args.compiler or "/bin/echo"
+
+    port = free_port()
+    base = f"http://127.0.0.1:{port}"
+    res = Results()
+
+    with tempfile.TemporaryDirectory(prefix="nbcc_hardening_") as timing_root:
+        env = dict(os.environ, NBCC_FHETCH_TIMING_ROOT=timing_root)
+        proc = subprocess.Popen(
+            [args.server_bin, "--port", str(port), "--bind", "127.0.0.1",
+             "--exec", compiler],
+            env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        try:
+            if not wait_healthy(base, proc):
+                out = proc.stdout.read() if proc.stdout else ""
+                sys.exit(f"error: server did not become healthy on {base}\n{out}")
+            print(f"server up on {base} (exec={compiler})\n")
+            run_checks(base, res, args.project, real_compiler, timing_root)
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+    print()
+    if res.failures:
+        print(f"FAILED ({len(res.failures)}):")
+        for f in res.failures:
+            print(f"  - {f}")
+        return 1
+    print("all transport hardening checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/fhetch_transport/archive.cpp
+++ b/src/fhetch_transport/archive.cpp
@@ -15,6 +15,13 @@ namespace {
 
 constexpr const char  kMagic[4] = {'N', 'B', 'A', 'R'};
 
+// Upper bound on a single entry's name. Real fhetch projects nest a handful of
+// levels (epoch_N/serialized_probes/<probe>.ct); 4 KiB is far past anything
+// legitimate and keeps a bogus name_len from being buffered before we can
+// reject it.
+constexpr std::uint32_t kMaxEntryNameLen   = 4096;
+constexpr std::size_t   kMaxEntryNameParts = 64;
+
 // Append n bytes of `value` (little-endian) to `out`.
 template <typename T>
 void append_le(std::string& out, T value) {
@@ -56,6 +63,57 @@ void validate_relative_path(const std::filesystem::path& rel) {
                                      + rel.string() + "'");
         }
     }
+}
+
+// Ingress-only name check, layered on top of validate_relative_path().
+//
+// Traversal is not the whole risk for a name we did not produce. Because the
+// format stores names verbatim, an archive arriving over the network can create
+// files whose names contain spaces, quotes, newlines, `;`, `$(...)`, or a
+// leading `-` inside the extraction root. None of that escapes the root, but it
+// turns into an injection or an argument-smuggle the moment anything downstream
+// globs or shells over the extracted tree. So allowlist the characters real
+// fhetch projects actually use and reject everything else.
+//
+// Deliberately NOT applied to pack_directory(): those names come from probe
+// tags that the compiler has already produced, and aborting a completed run
+// over a probe name would trade a live-path regression for no security gain.
+// The trust asymmetry is the point — this guards bytes off the wire.
+void validate_untrusted_entry_name(const std::filesystem::path& rel,
+                                   const std::string& raw) {
+    auto bad = [&raw](const char* why) {
+        return std::runtime_error(std::string("archive entry name rejected (")
+                                  + why + "): '" + raw + "'");
+    };
+
+    if (raw.size() > kMaxEntryNameLen) {
+        throw bad("too long");
+    }
+
+    std::size_t parts = 0;
+    for (const auto& part : rel) {
+        const auto component = part.string();
+        if (component == ".") {
+            continue;  // harmless "./" noise; not a component
+        }
+        if (++parts > kMaxEntryNameParts) {
+            throw bad("too deeply nested");
+        }
+        // A leading '-' would be read as an option flag by any tool that later
+        // receives this name as an argument.
+        if (component[0] == '-') {
+            throw bad("component starts with '-'");
+        }
+        for (unsigned char c : component) {
+            if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+                (c >= '0' && c <= '9') ||
+                 c == '_' || c == '.' || c == '-' || c == '+' ||
+                 c == '=' || c == ',' || c == '@')
+                continue;
+            throw bad("illegal character");
+        }
+    }
+    if (parts == 0) throw bad("no usable path component");
 }
 
 }  // namespace
@@ -213,6 +271,12 @@ ArchiveUnpacker::feed(const char* data, std::size_t len) {
             case State::NameLen: {
                 std::size_t pos = 0;
                 const auto name_len = read_le<uint32_t>(pending_, pos);
+                // Reject before `need_` commits us to buffering that many bytes.
+                if (name_len == 0 || name_len > kMaxEntryNameLen) {
+                    throw std::runtime_error(
+                        "ArchiveUnpacker: implausible entry name length: "
+                        + std::to_string(name_len));
+                }
                 state_ = State::Name; need_ = name_len; pending_.clear();
                 break;
             }
@@ -228,6 +292,7 @@ ArchiveUnpacker::feed(const char* data, std::size_t len) {
 
                 fs::path rel(cur_name_);
                 validate_relative_path(rel);
+                validate_untrusted_entry_name(rel, cur_name_);
                 fs::path out_path = dest_ / rel;
                 fs::create_directories(out_path.parent_path());
                 cur_file_.open(out_path, std::ios::binary | std::ios::trunc);
@@ -292,6 +357,7 @@ unpack_into(const std::string& archive,
 
         fs::path rel(name);
         validate_relative_path(rel);
+        validate_untrusted_entry_name(rel, name);
         fs::path out_path = dest / rel;
         fs::create_directories(out_path.parent_path());
 

--- a/src/fhetch_transport/server.cpp
+++ b/src/fhetch_transport/server.cpp
@@ -21,6 +21,8 @@
 
 #include "httplib.h"
 
+#include <algorithm>
+#include <cerrno>
 #include <csignal>
 #include <cstdio>
 #include <cstdlib>
@@ -33,7 +35,14 @@
 #include <system_error>
 #include <vector>
 
-#include <unistd.h>  // mkdtemp (macOS/BSD), getpid
+#include <spawn.h>     // posix_spawnp — replaces popen()/system()
+#include <sys/wait.h>  // waitpid, WIFEXITED/WEXITSTATUS
+#include <unistd.h>    // mkdtemp (macOS/BSD), pipe, read, close
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+// -- POSIX defines environ as char**; it cannot be const-qualified and still be
+//    the thing posix_spawnp() accepts. Not ours to change.
+extern char** environ;
 
 namespace {
 
@@ -45,6 +54,10 @@ struct ServerArgs {
     int         port = nft::kDefaultPort;
     std::string compiler_bin;
     std::string timing_root;  // NBCC_FHETCH_TIMING_ROOT; empty → feature off
+    // Include compiler/unpacker output in HTTP error bodies. Off by default so
+    // the daemon does not hand server-side paths and internals to whoever can
+    // reach the port; a server-side flag, never settable from a request.
+    bool        return_logs = false;
 };
 
 void print_usage() {
@@ -56,7 +69,11 @@ void print_usage() {
         "  --bind addr         Bind address (default 0.0.0.0).\n"
         "  --exec PATH         Compiler binary to invoke per request.\n"
         "                      Falls back to $NBCC_FHETCH_COMPILER_BIN,\n"
-        "                      then to \"nbcc_fhetch_replay\" on PATH.\n";
+        "                      then to \"nbcc_fhetch_replay\" on PATH.\n"
+        "  --return-logs       Include compiler/unpacker output in HTTP error\n"
+        "                      bodies. Off by default: those messages disclose\n"
+        "                      server-side paths. Intended for CI and local\n"
+        "                      debugging, not for a shared deployment.\n";
 }
 
 ServerArgs parse(int argc, char** argv) {
@@ -75,6 +92,7 @@ ServerArgs parse(int argc, char** argv) {
         else if (a == "--bind" && i + 1 < argc)       out.bind = argv[++i];
         else if (a.rfind("--exec=", 0) == 0)          out.compiler_bin = a.substr(7);
         else if (a == "--exec" && i + 1 < argc)       out.compiler_bin = argv[++i];
+        else if (a == "--return-logs")                out.return_logs = true;
         else if (a == "-h" || a == "--help") {
             print_usage();
             std::exit(0);
@@ -101,6 +119,26 @@ bool is_safe_cli_token(const std::string& s) {
             (c >= '0' && c <= '9') ||
              c == '_' || c == '.' || c == '/' || c == '-' || c == '=' ||
              c == '+' || c == ':' || c == ',')
+            continue;
+        return false;
+    }
+    return true;
+}
+
+// The target is stricter than is_safe_cli_token() because it does not stay a
+// CLI token: the compiler resolves it as a *path component* (devices/<target>/
+// spec.yaml). is_safe_cli_token() permits '/' and does not reject "..", so a
+// value that is perfectly safe to hand to a shell can still walk out of the
+// devices directory and load an attacker-chosen spec.yaml. Restrict to 
+// letters, digits, '_' and '.' and ban any ".." sequence or leading/trailing
+// dot
+bool is_safe_target(const std::string& s) {
+    if (s.empty() || s.size() > 64) return false;
+    if (s.front() == '.' || s.back() == '.') return false;
+    if (s.find("..") != std::string::npos) return false;
+    for (char c : s) {
+        if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+            (c >= '0' && c <= '9') || c == '_' || c == '.')
             continue;
         return false;
     }
@@ -142,9 +180,152 @@ std::string unique_tempdir(const std::string& prefix) {
     return buf.data();
 }
 
+// Sentinel: the child could not be started at all (bad path, no exec perm, out
+// of fds). Distinct from any status a started child can report.
+constexpr int kSpawnFailed = -1;
+
+// Run `bin` with `args` as argv[1..], capturing the child's stdout+stderr into
+// `log` (may be null to discard). Returns the child's exit status, 128+signal
+// if it was killed, or kSpawnFailed.
+//
+// No shell is involved. posix_spawnp() receives an explicit argv array, so a
+// value that would be a metacharacter to `sh` is inert here: it arrives at the
+// child as one literal argument. That removes quoting/injection concerns for 
+// every value on this command line
+//
+// `extra_env` holds "KEY=VALUE" assignments layered over the parent
+// environment, replacing any inherited assignment of the same key. argv and
+// envp are both built in the parent because posix_spawn() gives us no window to
+// allocate in the child — and the request threads make post-fork malloc unsafe.
+int run_capture(const std::string& bin,
+                const std::vector<std::string>& args,
+                const std::vector<std::string>& extra_env,
+                std::string* log) {
+    int fds[2];
+    if (::pipe(fds) != 0) {
+        return kSpawnFailed;
+    }
+
+
+    // posix_spawnp() wants char*, so keep our own mutable copies and hand out
+    // data() rather than casting away const on the caller's strings. Pointers
+    // are taken only once argv_storage has stopped growing.
+    std::vector<std::string> argv_storage;
+    argv_storage.reserve(args.size() + 1);
+    argv_storage.push_back(bin);
+    for (const auto& arg : args) {
+        argv_storage.push_back(arg);
+    }
+    std::vector<char*> argv;
+    argv.reserve(argv_storage.size() + 1);
+    for (auto& entry : argv_storage) {
+        argv.push_back(entry.data());
+    }
+    argv.push_back(nullptr);
+
+    // Environment: inherit the parent's unchanged in the common case. Only when
+    // a caller asks for an extra assignment do we build a private copy for this
+    // child.
+    //
+    // do NOT do: setenv() in the server process. mutating our own environment
+    // would race between concurrent requests and could route one job's telemetry
+    // into another job's directory. Per-child envp has no such coupling.
+    char** envp = environ;
+    std::vector<std::string> env_storage;  // outlives the spawn below
+    std::vector<char*>       env_ptrs;
+    if (!extra_env.empty()) {
+        for (char** ep = environ; ep != nullptr && *ep != nullptr; ++ep) {
+            const std::string inherited(*ep);
+            // Drop an inherited assignment that extra_env is about to replace.
+            const bool overridden = std::any_of(
+                extra_env.begin(), extra_env.end(),
+                [&inherited](const std::string& assignment) {
+                    const auto eq = assignment.find('=');
+                    return eq != std::string::npos &&
+                           inherited.compare(0, eq + 1, assignment, 0, eq + 1) == 0;
+                });
+            if (!overridden) {
+                env_storage.push_back(inherited);
+            }
+        }
+        for (const auto& assignment : extra_env) {
+            env_storage.push_back(assignment);
+        }
+        // Pointers are taken only after env_storage stops growing.
+        env_ptrs.reserve(env_storage.size() + 1);
+        for (auto& entry : env_storage) {
+            env_ptrs.push_back(entry.data());
+        }
+        env_ptrs.push_back(nullptr);
+        envp = env_ptrs.data();
+    }
+
+    posix_spawn_file_actions_t actions;
+    posix_spawn_file_actions_init(&actions);
+    posix_spawn_file_actions_addclose(&actions, fds[0]);
+    posix_spawn_file_actions_adddup2(&actions, fds[1], STDOUT_FILENO);
+    posix_spawn_file_actions_adddup2(&actions, fds[1], STDERR_FILENO);
+    posix_spawn_file_actions_addclose(&actions, fds[1]);
+
+    pid_t pid = 0;
+    const int spawn_rc = ::posix_spawnp(&pid, bin.c_str(), &actions, nullptr,
+                                        argv.data(), envp);
+    posix_spawn_file_actions_destroy(&actions);
+
+    // The parent must drop the write end or the read below never sees EOF.
+    ::close(fds[1]);
+    if (spawn_rc != 0) {
+        ::close(fds[0]);
+        return kSpawnFailed;
+    }
+
+    char buf[4096];
+    while (true) {
+        const ssize_t n = ::read(fds[0], buf, sizeof(buf));
+        if (n > 0) {
+            if (log != nullptr) {
+                log->append(buf, static_cast<std::size_t>(n));
+            }
+            continue;
+        }
+        if (n < 0 && errno == EINTR) {
+            continue;
+        }
+        break;
+    }
+    ::close(fds[0]);
+
+    int status = 0;
+    while (::waitpid(pid, &status, 0) < 0 && errno == EINTR) {
+        // retry
+    }
+    if (WIFEXITED(status)) {
+        return WEXITSTATUS(status);
+    }
+    if (WIFSIGNALED(status)) {
+        return 128 + WTERMSIG(status);
+    }
+    return kSpawnFailed;
+}
+
 struct Handler {
     std::string compiler_bin;
     std::string timing_root;  // empty → per-job timing dir disabled
+    bool        return_logs = false;  // --return-logs; see ServerArgs
+
+    // Compose an error body for the client. `summary` is always safe to send;
+    // `detail` (a compiler log, or an unpacker message carrying our temp path)
+    // is appended only when the operator opted in with --return-logs. Logs
+    // contain server internal info and should not be passed to the client
+
+    std::string detail_for_client(const std::string& summary,
+                                  const std::string& detail) const {
+        if (!return_logs) {
+            return summary + "\n(server log withheld; run the server with "
+                             "--return-logs to include it)\n";
+        }
+        return summary + "\n---log---\n" + detail;
+    }
 
     void operator()(const httplib::Request& req, httplib::Response& res,
                     const httplib::ContentReader& content_reader) const {
@@ -166,8 +347,13 @@ struct Handler {
             reject(400, "missing header " + std::string(nft::kTargetHeader) + "\n");
             return;
         }
-        if (!is_safe_cli_token(target) ||
-            (!project.empty() && !is_safe_cli_token(project))) {
+        if (!is_safe_target(target)) {
+            reject(400, "header " + std::string(nft::kTargetHeader) +
+                        " must match [A-Za-z0-9_.]+ (no '..', no leading/"
+                        "trailing '.')\n");
+            return;
+        }
+        if (!project.empty() && !is_safe_cli_token(project)) {
             reject(400, "header values must match [A-Za-z0-9_.+=/,:-]+\n");
             return;
         }
@@ -225,61 +411,65 @@ struct Handler {
                       << " files into " << tempdir
                       << " (target=" << target << ")\n";
         } catch (const std::exception& e) {
+            // ArchiveUnpacker embeds the output path in its errors, so what()
+            // discloses our mkdtemp directory — gate it like any other detail.
+            std::cerr << "[nbcc_fhetch_replay_server] archive unpack failed: "
+                      << e.what() << "\n";
             res.status = 400;
-            res.set_content(std::string("archive unpack failed: ") + e.what() + "\n",
+            res.set_content(detail_for_client("archive unpack failed", e.what()),
                             "text/plain");
+            // Drop the partially-extracted tree: leaving it behind both grows
+            // unboundedly and preserves attacker-planted files at a path the
+            // error above would otherwise have just disclosed.
+            if (!tempdir.empty()) {
+                std::error_code ec; fs::remove_all(tempdir, ec);
+            }
             return;
         }
 
         // ---- Invoke the compiler binary -----------------------------
-        // We build a shell command with pre-validated tokens only and
-        // capture stderr alongside stdout so failure diagnostics come
-        // back to the client without a second round trip.
-        std::ostringstream cmd;
+        // argv is assembled as a vector, not a shell string: see run_capture().
+        std::vector<std::string> args{"--project=" + tempdir,
+                                      "--target=" + target};
+        if (!opt_flag.empty()) args.push_back(opt_flag);  // pre-validated -O<n>
+
         // Optional per-job timing dir → NB_TIMING_SUMMARY_DIR for the compiler.
         // Path is <root>/<job-id>, both server-controlled (root from env, job id
-        // validated to [A-Za-z0-9-]+), so it's safe to inline as a `sh` env
-        // assignment. Create it so the compiler can write; the caller (Fog
-        // worker) collects and removes it after the run.
+        // validated to [A-Za-z0-9-]+). Create it so the compiler can write; the
+        // caller (Fog worker) collects and removes it after the run.
+        std::vector<std::string> extra_env;
         if (!timing_dir.empty()) {
             std::error_code ec;
             fs::create_directories(timing_dir, ec);
-            if (ec)
+            if (ec) {
                 std::cerr << "[nbcc_fhetch_replay_server] could not create timing dir "
                           << timing_dir << ": " << ec.message() << " (skipping)\n";
-            else
-                cmd << "NB_TIMING_SUMMARY_DIR=" << timing_dir << " ";
+            } else {
+                extra_env.push_back("NB_TIMING_SUMMARY_DIR=" + timing_dir);
+            }
         }
-        cmd << compiler_bin
-            << " --project=" << tempdir
-            << " --target="  << target;
-        if (!opt_flag.empty()) cmd << " " << opt_flag;  // pre-validated -O<n>
-        cmd << " 2>&1";
 
         std::string log;
-        int exit_code = -1;
-        {
-            FILE* pipe = ::popen(cmd.str().c_str(), "r");
-            if (!pipe) {
-                res.status = 500;
-                res.set_content("could not spawn compiler binary\n", "text/plain");
-                std::error_code ec; fs::remove_all(tempdir, ec);
-                return;
-            }
-            char buf[4096];
-            while (std::size_t n = std::fread(buf, 1, sizeof(buf), pipe)) {
-                log.append(buf, n);
-            }
-            exit_code = ::pclose(pipe);
-            if (WIFEXITED(exit_code)) exit_code = WEXITSTATUS(exit_code);
-        }
+        const int exit_code = run_capture(compiler_bin, args, extra_env, &log);
+
+        // The log always goes to the server's own stdout; whether any of it
+        // reaches the client is the operator's call (--return-logs).
         std::cout << log;
+
+        if (exit_code == kSpawnFailed) {
+            res.status = 500;
+            res.set_content("could not spawn compiler binary\n", "text/plain");
+            std::error_code ec; fs::remove_all(tempdir, ec);
+            return;
+        }
 
         if (exit_code != 0) {
             res.status = 500;
-            std::string msg = "nbcc_fhetch_replay exited " +
-                              std::to_string(exit_code) + "\n---log---\n" + log;
-            res.set_content(msg, "text/plain");
+            res.set_content(detail_for_client(
+                                "nbcc_fhetch_replay exited " +
+                                    std::to_string(exit_code),
+                                log),
+                            "text/plain");
             std::error_code ec; fs::remove_all(tempdir, ec);
             return;
         }
@@ -288,8 +478,10 @@ struct Handler {
         fs::path probes = fs::path(tempdir) / "serialized_probes";
         if (!fs::exists(probes)) {
             res.status = 500;
-            res.set_content("compiler succeeded but wrote no serialized_probes/\n"
-                            "---log---\n" + log, "text/plain");
+            res.set_content(detail_for_client(
+                                "compiler succeeded but wrote no serialized_probes/",
+                                log),
+                            "text/plain");
             std::error_code ec; fs::remove_all(tempdir, ec);
             return;
         }
@@ -342,7 +534,7 @@ int main(int argc, char** argv) {
     std::signal(SIGINT,  shutdown_handler);
     std::signal(SIGTERM, shutdown_handler);
 
-    Handler handler{args.compiler_bin, args.timing_root};
+    Handler handler{args.compiler_bin, args.timing_root, args.return_logs};
     srv.Post(nft::kReplayPath,
              [&handler](const httplib::Request& req, httplib::Response& res,
                         const httplib::ContentReader& content_reader) {
@@ -354,15 +546,16 @@ int main(int argc, char** argv) {
                 res.set_content("ok\n", "text/plain");
             });
 
-    // Pre-flight: resolve the compiler binary exactly the way popen() will,
-    // and fail loud at startup if it's not callable. Much better than
-    // handing every incoming replay an opaque 500. We let `sh -c "<bin>
-    // --help"` do the work so PATH lookup and shebang handling match the
-    // actual invocation site. Exit status 127 from sh means "not found".
+    // Pre-flight: resolve the compiler binary exactly the way the request path
+    // will, and fail loud at startup if it's not callable. Much better than
+    // handing every incoming replay an opaque 500. Reusing run_capture() keeps
+    // PATH lookup identical to the actual invocation site; a kSpawnFailed here
+    // is precisely "could not be executed" (what `sh` used to report as 127).
+    // The child's own exit status is ignored — some binaries exit non-zero on
+    // --help, and that was never what this check was about.
     {
-        std::string probe = args.compiler_bin + " --help >/dev/null 2>&1";
-        int rc = std::system(probe.c_str());
-        if (WIFEXITED(rc) && WEXITSTATUS(rc) == 127) {
+        const int rc = run_capture(args.compiler_bin, {"--help"}, {}, nullptr);
+        if (rc == kSpawnFailed) {
             std::cerr << "[nbcc_fhetch_replay_server] compiler binary not found: '"
                       << args.compiler_bin << "'\n"
                       << "  set NBCC_FHETCH_COMPILER_BIN or pass --exec "


### PR DESCRIPTION
The daemon accepts an archive plus headers from the network and runs the compiler against them. Four fixes, plus a regression suite for the refusals.

X-Target: validate as a path component, not a CLI token. The compiler resolves it as devices/<target>/spec.yaml, and is_safe_cli_token() permits '/' and does not reject "..", so a value that is safe to hand to a shell could still escape the devices directory and load an attacker-chosen spec.yaml. is_safe_target() restricts to [A-Za-z0-9_.] and bans "..", leading and trailing dots. Multi-dot and underscore ids (fpga6.1.0, func_sim_hw) stay valid.

Archive entry names: allowlist the charset on ingress. The format stores names verbatim, so an archive off the wire could create files whose names carry spaces, quotes, newlines or a leading '-' inside the extraction root -- an injection for anything downstream that globs or shells over the tree. Applied only to the unpack path: names produced by pack_directory() come from probe tags the compiler already emitted, and failing a completed run over a probe name would be a regression for no security gain. Implausible name lengths are refused before buffering.

Error bodies: withhold detail unless --return-logs. Both the compiler log and the unpacker's messages contain absolute server-side paths, including the per-request mkdtemp directory. Callers have no need for them, and they make server internals easier to probe. Full text still goes to the server's stdout. The flag is server-side only and can never be set from a request. Also drop the partially extracted tree on unpack failure, which previously survived and grew unbounded.

popen()/system() -> posix_spawnp(). No shell is involved now, so values we do not validate because they are server-side (the mkdtemp path, which inherits $TMPDIR, and the timing root) can no longer be misquoted. The timing dir moves from a `VAR=x cmd` shell prefix to a per-child envp entry; notably not setenv(), which would race between request threads and could route one job's telemetry into another job's directory. Also yields a real exit status instead of WIFEXITED() on -1.

scripts/test_transport_hardening.py drives the daemon with hostile input and asserts the refusals fire, which the happy-path transport test cannot. Cases 1-5 need no compiler -- every one is refused before anything is spawned -- so it runs in test-client-release with a stub --exec. Pass COMPILER_BIN and PROJECT to also verify the per-job timing dir still reaches the compiler.