### PR TITLE
Avoid /dev/stderr in test_transport_mult.sh

### DIFF
--- a/scripts/test_transport_mult.sh
+++ b/scripts/test_transport_mult.sh
@@ -112,7 +112,18 @@ LD_LIBRARY_PATH="$OPENFHE_LIB" "$mult_server" mult_keys --target="$TARGET" --no-
 
 echo
 echo "=== [4/5] mult_decrypt ==="
-if ! LD_LIBRARY_PATH="$OPENFHE_LIB" "$mult_decrypt" mult_keys | tee /dev/stderr | grep -q '^\[PASS\]'; then
+# Capture instead of `| tee /dev/stderr |`: /dev/stderr is a magic symlink to
+# /proc/self/fd/2, so tee re-opens the underlying inode and needs write
+# permission on it. In a container whose stderr pipe is owned by root while the
+# script runs as a non-root uid, that fails with EACCES. Reprinting through the
+# already-open fd 2 avoids the re-open. It also drops the grep -q/pipefail
+# race, where grep exiting on match could SIGPIPE tee and fail a passing run.
+set +e
+decrypt_out=$(LD_LIBRARY_PATH="$OPENFHE_LIB" "$mult_decrypt" mult_keys 2>&1)
+decrypt_rc=$?
+set -e
+printf '%s\n' "$decrypt_out" >&2
+if [ "$decrypt_rc" -ne 0 ] || ! grep -q '^\[PASS\]' <<<"$decrypt_out"; then
   echo
   echo "=== ✗ transport round-trip FAIL (decrypt) ==="
   exit 1


### PR DESCRIPTION
`scripts/test_transport_mult.sh` piped the decrypt output through
`tee /dev/stderr` so it stayed visible while `grep -q` consumed stdout.

This fails in containers with `/dev/stderr: Permission denied`. `/dev/stderr`
is a symlink to `/proc/self/fd/2`, which is a magic symlink: opening it
re-opens the underlying inode with the caller's credentials rather than
duplicating fd 2. When the container's stderr pipe is owned by root and the
script runs as a non-root uid, `tee` cannot re-open it.

Capture the output into a variable and reprint it with `printf ... >&2`, which
writes through the already-open fd 2 and needs no re-open.

Two side benefits:

- Removes a `grep -q`/`pipefail` race. `grep -q` exits on first match, so it
  could `SIGPIPE` `tee` and make `pipefail` report failure on a passing run.
- The `[FAIL]` line from `decrypt.cpp` goes to stderr and previously bypassed
  the `tee`. The capture uses `2>&1`, so it now shows up too.

`mult_decrypt`'s exit code is now checked explicitly instead of relying on
`pipefail`.

Tested: `bash -n` passes, and an extracted harness gives the right branch and
exit code for pass, mismatch, and silent-crash (exit 139, no output) cases.
Note the original `EACCES` cannot be reproduced on macOS, where `/dev/fd/N` is
a true dup rather than a re-open.
