### PR TITLE
fix: don't leak the loader search path into the replay subprocess

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,28 @@ ifndef NUM_CPUS
   endif
 endif
 
+# ==============================================================================
+# RUN_WITHOUT_LIBRARY_PATH — prefix to run a command with the loader search
+# path cleared
+#
+# The exports above make this repo's own OpenFHE install visible to every
+# recipe, which is what our examples need. But an example that dispatches to
+# the compiler's replay binary spawns it as a child process, and the child
+# inherits that environment. The replay binary ships alongside the OpenFHE it
+# was linked against and finds it through its own baked-in rpath; an inherited
+# search path takes precedence over that rpath and makes it load ours instead.
+# The two are independent builds, so that substitution is not safe.
+#
+# Both sides already resolve their own libraries without help — our examples
+# via the rpath set by set_openfhe_rpath() in examples/CMakeLists.txt, the
+# replay binary via its own. So clear the variables for the dispatching
+# process and let each side use its own rpath.
+#
+# Use this for any example invoked with a niobium target; plain client-only
+# examples do not need it.
+# ==============================================================================
+RUN_WITHOUT_LIBRARY_PATH := env -u LD_LIBRARY_PATH -u DYLD_LIBRARY_PATH
+
 # Self-locating rpath token for the OpenFHE .so install (see config-openfhe).
 ifeq ($(UNAME_S), Darwin)
   OPENFHE_ORIGIN_RPATH := @loader_path
@@ -450,7 +472,7 @@ test-mult-target-release: build-release ## Run mult with --target=$(TARGET). Ove
 	@echo ""
 	@echo "=== [2/3] mult_server --target=$(TARGET) (hollow record → dispatch to compiler) ==="
 	NBCC_FHETCH_REPLAY=$(NIOBIUM_COMPILER_ROOT)/build/nbcc_fhetch_replay \
-	LD_LIBRARY_PATH=$(OPENFHE_INSTALL_DIR)/lib:$(NIOBIUM_COMPILER_ROOT)/build:$(NIOBIUM_COMPILER_ROOT)/deps/photovoltaic/build/ntl/lib:$(LD_LIBRARY_PATH) \
+	$(RUN_WITHOUT_LIBRARY_PATH) \
 		$(BUILD_DIR)/examples/mult_server mult_keys --target=$(TARGET) --no-ring-dim-check
 	@echo ""
 	@echo "=== [3/3] mult_decrypt ==="

--- a/scripts/test_transport_mult.sh
+++ b/scripts/test_transport_mult.sh
@@ -108,7 +108,14 @@ echo "=== [3/5] mult_server --target=$TARGET (through transport) ==="
 # hits it — matches the production install layout.
 export PATH="$TRANSPORT_DIR:$PATH"
 export NBCC_FHETCH_SERVER="http://127.0.0.1:$PORT"
-LD_LIBRARY_PATH="$OPENFHE_LIB" "$mult_server" mult_keys --target="$TARGET" --no-ring-dim-check
+# Clear the loader search path for this one: mult_server dispatches to the
+# compiler's replay binary, and a child process inherits our search path,
+# which would override the rpath the replay binary uses to find the OpenFHE
+# it was built against. Both binaries resolve their own libraries via rpath,
+# so no search path is needed here. (mult_client / mult_decrypt above and
+# below are client-only and keep theirs.)
+env -u LD_LIBRARY_PATH -u DYLD_LIBRARY_PATH \
+  "$mult_server" mult_keys --target="$TARGET" --no-ring-dim-check
 
 echo
 echo "=== [4/5] mult_decrypt ==="


### PR DESCRIPTION
## Problem

`compiler-tests.yml` fails at startup with an undefined symbol when the replay binary loads.

The Makefile puts this repo's own OpenFHE install on the loader search path so our examples can find it. Examples run against a niobium target dispatch to the compiler's replay binary as a **child process**, and the child inherits that search path.

An inherited `LD_LIBRARY_PATH` takes precedence over `DT_RUNPATH`, which is how the replay binary locates the OpenFHE it was built against. So the child silently loads *our* OpenFHE instead of its own. Both install under the same SONAME, so there's no version guard — first on the path wins, with no diagnostic until a symbol fails to resolve.

The two are independent builds. Whenever they differ at all, this surfaces as an undefined symbol at startup. That makes CI break on unrelated library updates on either side, which is what's happening now.

## Fix

Clear `LD_LIBRARY_PATH` / `DYLD_LIBRARY_PATH` for the dispatching example, in `test-mult-target-release` and in `scripts/test_transport_mult.sh`.

Neither side needs the search path — both already resolve their own libraries via rpath:

- our examples through `set_openfhe_rpath()` in `examples/CMakeLists.txt`, which bakes an absolute rpath into every example and applies to `mult_server` (these run out of the build tree, so `BUILD_RPATH` is live)
- the replay binary through its own rpath, which resolves relative to where it sits

With nothing on the search path to compete, each side loads the OpenFHE it was built against. The processes stay independent, which is what they always should have been — nothing about a parent/child process pair requires them to share a library.

Client-only examples (`mult_client`, `mult_decrypt`) don't dispatch to anything and keep their search path unchanged.

## Notes

- The removed line also referenced a path that never existed on the CI runner, so that element was a no-op.
- This does not change the on-disk data format compatibility already noted above `test-mult-target-release`; that's a separate concern and is unaffected.
- `env -u` is supported by both GNU and BSD `env`.

## Test plan

- [x] `make -n test-mult-target-release` expands as intended
- [x] `bash -n scripts/test_transport_mult.sh`
- [x] Replay binary loads cleanly with both variables unset
- [ ] `compiler-tests.yml` green in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)