### PR TITLE
ci: stop cloning the fbs submodule tree twice, and retry on NAT drops

### DIFF
--- a/.github/workflows/fbs-consumer-check.yml
+++ b/.github/workflows/fbs-consumer-check.yml
@@ -66,21 +66,67 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: NiobiumInc/fetch-by-similarity-submission
-          submodules: recursive
           path: fbs
+          # Deliberately NOT `submodules: recursive` — the next step does it.
+          #
+          # This step used to clone the whole niobium-client subtree at fbs's
+          # *current* pin, only for the next step to repoint niobium-client and
+          # re-init it, cloning that same subtree a second time. fbs has exactly
+          # one submodule, so nearly all of that first pass was thrown away.
+          #
+          # That matters because these runners have no external IP and egress
+          # through a NAT with a per-VM port budget. Every clone holds a port
+          # for the NAT's TIME_WAIT window after it finishes, so the duplicate
+          # pass roughly doubled the ports a single job needs. Past the budget
+          # connections are dropped silently and git sits in SYN retry until the
+          # kernel gives up — which is why this surfaced as a ~135s "Failed to
+          # connect to github.com port 443: Connection timed out" at varying
+          # points, rather than as a fast refusal.
+          #
+          # This is a mitigation, not the fix: it lowers the port count enough
+          # to stay under the budget. The real fix is on the NAT itself (raise
+          # min-ports-per-vm, enable dynamic port allocation, shorten
+          # tcp-time-wait-timeout) in NiobiumInc/gcp-github-runners.
+          submodules: false
 
       - name: Point fbs's niobium-client submodule at this commit
-        working-directory: fbs/submission/niobium-client
+        working-directory: fbs
         run: |
+          # Retry the network steps. The port budget is per-VM and shared with
+          # everything else the job does, so we can still lose. Ports come back
+          # on the NAT's TIME_WAIT timer, so a retry has to wait that out — a
+          # few-second backoff would just burn attempts against a full table.
+          retry() {
+            n=1
+            until "$@"; do
+              if [ "$n" -ge 3 ]; then
+                echo "::error::network step failed after $n attempts: $*"
+                return 1
+              fi
+              n=$((n + 1))
+              echo "network step failed; waiting 130s for NAT ports to free (attempt $n/3)"
+              sleep 130
+            done
+          }
+
+          # Init just the one submodule, non-recursively: fetching its nested
+          # tree at the old pin is wasted when we are about to repoint it.
+          retry git submodule update --init submission/niobium-client
+
+          cd submission/niobium-client
           # refs/pull/<N>/head always exists on the base repo, for PRs from
           # forks too, so this works regardless of who opened the PR.
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch --no-tags --depth=1 origin "refs/pull/${{ github.event.pull_request.number }}/head"
+            retry git fetch --no-tags --depth=1 origin "refs/pull/${{ github.event.pull_request.number }}/head"
           else
-            git fetch --no-tags --depth=1 origin "${{ github.sha }}"
+            retry git fetch --no-tags --depth=1 origin "${{ github.sha }}"
           fi
           git checkout --detach FETCH_HEAD
-          git submodule update --init --recursive
+
+          # Runs inside the submodule, as before. From the fbs root this would
+          # reset niobium-client back to fbs's pinned commit and undo the
+          # checkout above.
+          retry git submodule update --init --recursive
 
       - name: Verify SDK is mounted (no version printed)
         run: |


### PR DESCRIPTION
`fbs-consumer-check` was failing at the submodule step with `Failed to connect to github.com port 443 ... Connection timed out` after ~135s, at varying points and against varying repos — 11 consecutive runs, and re-running stopped helping.

## Cause

The runners are created with `--no-address`, so all egress goes through Cloud NAT. The NAT is provisioned with no port configuration:

```bash
gcloud compute routers nats create "$NAT" \
    --router="$ROUTER" --region="$REGION" \
    --auto-allocate-nat-external-ips --nat-all-subnet-ip-ranges
```

No `--min-ports-per-vm` and no `--enable-dynamic-port-allocation` means the GCP default of **64 ports per VM**. Every clone holds a port for the NAT's TIME_WAIT window (120s default) *after* it closes, so ports accumulate across a job no matter how the clones are spaced — staggering doesn't help. Past the budget, connections are dropped silently and git sits in SYN retry until the kernel gives up, which is why this appears as a ~135s timeout rather than a fast refusal, and why the failure point moves around.

The egress firewall is not involved: it allows `tcp:443` to `0.0.0.0/0`.

## Changes

Both aim at needing fewer ports.

**Stop cloning the tree twice.** The checkout step used `submodules: recursive`, cloning the whole niobium-client subtree at fbs's *current* pin — only for the next step to repoint niobium-client and clone that subtree again at the PR's pins. fbs has exactly one submodule, so that first pass was almost entirely discarded work that roughly doubled the ports a single job needed. Checkout now skips submodules; the next step inits just `submission/niobium-client` non-recursively before repointing it.

**Retry the network operations.** Up to 3 attempts, waiting out the TIME_WAIT window between them. A short backoff would only burn attempts against a still-full table.

The recursive init deliberately stays *inside* the submodule. Run from the fbs root it would reset niobium-client back to fbs's pinned commit and silently undo the repoint — the job would then build the wrong client and still look green.

## Result

Verified on the bump branch: the submodule step passed for the first time in 11 attempts, and the job ran all the way through the build to the sanity test. (It then failed for an unrelated reason, addressed in the PR stacked on this one.)

## This is a mitigation, not the fix

It lowers the port count enough to stay under the budget. The real fix is on the NAT itself, in `NiobiumInc/gcp-github-runners`:

```bash
gcloud compute routers nats update gha-runner-nat \
  --router=gha-runner-router --region=us-west1 --project=github-runner-499901 \
  --min-ports-per-vm=1024 \
  --enable-dynamic-port-allocation --max-ports-per-vm=8192 \
  --tcp-time-wait-timeout=30s
```

Until that lands, any job whose clone count grows past the budget will hit this again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)