### PR TITLE
Docs/update quickstart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,25 +2,26 @@
 
 Guidance for Claude Code (and other agents) working in this repository.
 
-> **Designing or building an FHE application? Read
-> [`.claude/skills/fhe-application-design/SKILL.md`](.claude/skills/fhe-application-design/SKILL.md)
-> first (run `make sync-skill` to install it) — do not skip the design stages.** It is a staged design guide (privacy
-> model → feasibility → scheme → circuit → SIMD data layout → parameters →
-> codegen). This applies whether you enter through the nb DSL (`dsl_fhe/`),
-> instrumented OpenFHE (`examples/`), or direct FHETCH IR — the design work comes
-> before the code either way.
+> **Designing or building an FHE application? Install and follow the
+> `fhe-application-design` skill — do not skip the design stages.** It walks
+> privacy model, feasibility, scheme and parameter selection, a plaintext twin
+> validated against your own reference computation, then the encrypted program
+> and its Fog deployment. This applies whether you enter through the nb DSL
+> (`dsl_fhe/`), instrumented OpenFHE (`examples/`), or direct FHETCH IR — the
+> design work comes before the code either way.
 >
 > The skill is installed on demand, not committed: run `make sync-skill` to
-> install it into `.claude/skills/` and `.agents/skills/` (both gitignored). End
-> users of the catalog can instead run `npx skills add NiobiumInc/niobium-skills
-> --skill fhe-application-design`.
+> install it into `.claude/skills/` (Claude Code) and `.agents/skills/` (Open
+> Agent standard: Codex, Cursor, Copilot, Gemini, and others), both gitignored;
+> once installed it auto-loads. End users of the catalog can instead run
+> `npx skills add NiobiumInc/niobium-skills --skill fhe-application-design`.
 
 ## Project Overview
 
 **Niobium Client** is the open-source client stack for the Niobium Mistic FHE
 accelerator, with four entry points converging on one FHETCH Polynomial IR
-trace: the **nb DSL + design skill** (AI-agent coding, `dsl_fhe/` +
-`.claude/skills/fhe-application-design`), **instrumented OpenFHE**
+trace: the **nb DSL + design skill** (AI-agent coding, `dsl_fhe/` + the
+`fhe-application-design` skill), **instrumented OpenFHE**
 (application developers, `examples/`), **direct FHETCH IR emission** (compiler
 writers, via `libnbfhetch` + `src/fhetch_transport/`), and **HAZE** (FHE
 library integrators, CUDA-shaped C API, `vendor/niobium-haze`). It wires the

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ There are four ways in, by audience:
 
 | You are… | Entry point | Start here |
 |---|---|---|
-| **An AI coding agent** (or pairing with one) | **nb DSL + design skill** — a staged FHE design methodology that auto-loads for Claude Code, OpenAI Codex, and other agentskills.io-compatible agents, paired with a compact DSL whose compiler generates all the plumbing | [`dsl_fhe/`](dsl_fhe/README.md), [`.claude/skills/`](.claude/skills/fhe-application-design) & [`.agents/skills/`](.agents/skills/fhe-application-design) |
+| **An AI coding agent** (or pairing with one) | **nb DSL + design skill** — a staged FHE design methodology that auto-loads for Claude Code, OpenAI Codex, and other agentskills.io-compatible agents, paired with a compact DSL whose compiler generates all the plumbing | [`dsl_fhe/`](dsl_fhe/README.md), [`niobium-skills`](https://github.com/NiobiumInc/niobium-skills) |
 | **An application developer** with OpenFHE C++ | **Instrumented OpenFHE** — write standard `EvalMult`/`EvalAdd`/… code, bracket it with `niobium::compiler()` calls; probes record everything | [Instrumenting an OpenFHE application](#entry-point-2--openfhe-for-application-developers), [`examples/`](examples/) |
 | **A compiler / code-generator author** | **FHETCH Polynomial IR** — emit the IR directly through the recording API (or the text trace format) and use the session, replay, and transport machinery as your backend | [`niobium-fhetch`](https://github.com/NiobiumInc/niobium-fhetch), [`src/fhetch_transport/`](src/fhetch_transport/) |
 | **An FHE library integrator** (GPU/accelerator back-ends) | **HAZE** — a CUDA-shaped C API (`hazeMalloc`/`hazeMemcpy`/`hazeNTT`/…): each call records one polynomial-level IR op, so CUDA-targeting FHE libraries port with minimal effort | [`vendor/niobium-haze`](https://github.com/NiobiumInc/niobium-haze) |
@@ -100,8 +100,8 @@ The combination is designed so an AI coding agent can take an application from
 
 - **The design skill** (installed from the
   [`niobium-skills`](https://github.com/NiobiumInc/niobium-skills)
-  catalog via `make sync-skill` into both [`.claude/skills/fhe-application-design`](.claude/skills/fhe-application-design)
-  and [`.agents/skills/fhe-application-design`](.agents/skills/fhe-application-design))
+  catalog via `make sync-skill` into both `.claude/skills/fhe-application-design`
+  and `.agents/skills/fhe-application-design`)
   auto-loads in this repository for Claude Code (from `.claude/skills/`), OpenAI
   Codex, and other agentskills.io-compatible agents (from `.agents/skills/`). It
   walks the staged methodology — privacy model, feasibility, plaintext ground truth, scheme
@@ -506,7 +506,7 @@ want.** Need an idea?
 
 The skill asks about your FHE expertise as well as additional pertinent questions, including which niobium-client install (or container) you would like to use, how you would like to source any required data, and whether you would like your app written using OpenFHE or the Niobium FHE domain-specific language (DSL).
 
-**d. Validate it on your own machine.** The skill generates a full FHE application with each of the major components properly segmented. That means that it generates the following separate programs:
+**d. Validate it on your own machine.** The skill generates a full FHE application with each of the major components properly segmented. That means that it generates the following separate programs (exact names depend on your stage declarations):
 
 - keygen
 - encrypt

--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ sudo apt install -y build-essential cmake libssl-dev python3 git
 ```bash
 make sync         # fetch submodules: niobium-fhetch + nested OpenFHE + json + niobium-haze
 make release      # build OpenFHE + libnbfhetch + transport client + examples (Release)
+make install-release  # install the client SDK to vendor/lib/niobium-client
 make install-cli  # install fog + nbcc_fhetch_replay to ~/.local/bin
 make sync-skill   # install the FHE design skill into .claude + .agents
 ```
@@ -423,16 +424,22 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc && exec $SHELL
 fog --help
 ```
 
-### 4. Log in and submit a sample job
+### 4. Log in
 
 ```bash
 fog init                                    # optional: write ~/.fog/config with defaults
-fog login -u you@example.com                # prompts for password; mints + stores an API key
+fog login -u you@example.com                # console email; prompts for password; mints + stores an API key
+fog list                                    # confirms auth (an empty list is fine)
+```
+
+### 5. Submit a sample job
+
+```bash
 cd build/examples
-./mult_client mult_keys 7 13 65536          # will create the mult_keys directory, generate keys, and encrypt(ring dimension of 2^16)
+./mult_client mult_keys 7 13 65536          # creates mult_keys/, generates keys, encrypts (ring dimension 2^16)
 fog submit ./mult_server mult_keys --target=FOG
 fog list                                    # watch your jobs
-./mult_decrypt mult_keys                    #decrypt the results
+./mult_decrypt mult_keys                    # decrypt the results
 ```
 
 `fog submit ./app --target=FOG …` provisions a Fog job, blocks until a worker is
@@ -446,6 +453,98 @@ worker, and decrypt reveals the product. `mult_client`'s last argument is the ri
 dimension (`65536` = 2^16); the two integers before it are the operands. 
 `fog submit` wraps `mult_server` so its `replay()` dispatches to the assigned worker 
 instead of the local simulator.
+
+### 6. Use the Niobium skill to design and create your own FHE application
+
+The [FHE application design skill](https://github.com/NiobiumInc/niobium-skills)
+walks a coding agent through eleven stages: privacy model, feasibility, scheme
+and parameter selection, a plaintext twin validated against your own reference
+computation, then the encrypted program and its Fog deployment. A first design
+takes 30 to 60 minutes.
+
+**a. Make a folder for the application beside this repository.** Your
+application is its own repository; this one is a build dependency beside it:
+
+```bash
+mkdir -p ../my-fhe-app && cd ../my-fhe-app
+```
+
+**b. Install the skill into that folder.** The installer asks about your agent and
+writes the skill where that agent reads it:
+
+```bash
+npx skills add NiobiumInc/niobium-skills --skill fhe-application-design
+```
+
+Alternatively, install via GitHub:
+
+```bash
+git clone --depth 1 https://github.com/NiobiumInc/niobium-skills /tmp/niobium-skills
+
+# Claude Code, Claude Desktop
+mkdir -p .claude/skills && cp -r /tmp/niobium-skills/skills/fhe-application-design .claude/skills/
+
+# Codex, Cursor, Copilot, Gemini, Windsurf, Cline
+mkdir -p .agents/skills && cp -r /tmp/niobium-skills/skills/fhe-application-design .agents/skills/
+```
+
+**c. Start your coding agent in that folder and ask it to build what you
+want.** Need an idea?
+
+- Score a patient's 30-day readmission risk on a cloud the hospital does not
+  trust with the record.
+- Tell a utility which households can shed load during a peak event, from
+  meter readings each household keeps encrypted.
+- Grade a part from line-sensor readings without the vendor's cloud learning
+  the production volume.
+
+> **Note:** the skill wakes on the vocabulary of the problem: FHE, homomorphic
+> encryption, encrypted computation, computing on encrypted data, OpenFHE,
+> CKKS, the Niobium Fog. Naming it directly (`use the fhe-application-design
+> skill`) works too, as does describing a computation the computing party must
+> not be able to read.
+
+The skill asks about your FHE expertise as well as additional pertinent questions, including which niobium-client install (or container) you would like to use, how you would like to source any required data, and whether you would like your app written using OpenFHE or the Niobium FHE domain-specific language (DSL).
+
+**d. Validate it on your own machine.** The skill generates a full FHE application with each of the major components properly segmented. That means that it generates the following separate programs:
+
+- keygen
+- encrypt
+- server
+- decrypt
+
+The skill also generates scaffolding to simplify running and documenting the application, including:
+
+- a `README`
+- a `Makefile`
+- a `run.sh` environment wrapper that points at your chosen `niobium-client` installation, and
+- a `run_test.sh` harness that runs the full program end-to-end
+
+Your agent runs these as it iterates. The methodology enables you to test your program locally via CPU and a functional simulator before a Fog run to ensure program and mathematical correctness.
+
+```bash
+./run.sh "./run_test.sh --cpu"   # plain OpenFHE on your CPU, compared against the twin
+./run.sh "./run_test.sh --sim"   # the local simulator over the generated trace
+```
+
+### 7. Run your application on the Fog
+
+A bare `run_test.sh` targets the Fog. Your API key from step 4 is already in
+`~/.fog`:
+
+```bash
+cd ../my-fhe-app
+./run.sh "./run_test.sh"
+```
+
+The server step runs under `fog submit --target=FOG`, which provisions a job,
+streams your keys, ciphertext, and the generated trace to the assigned worker,
+computes there, and returns the encrypted result for the client side to
+decrypt and check. The key material moves before any compute starts, as in
+step 5.
+
+The Fog runs using ciphertexts with ring dimension 2^16; the generated harness keeps that
+check on for every submission.
 
 ### `fog` command reference
 

--- a/dsl_fhe/AGENTS.md
+++ b/dsl_fhe/AGENTS.md
@@ -1,10 +1,12 @@
 # DSL for FHE: Design Rationale and Compiler Guide
 
-> **Building an FHE app? Read the design skill first — do not skip the design
-> stages.** Before you write a single `.niob` file, read
-> [`../.claude/skills/fhe-application-design/SKILL.md`](../.claude/skills/fhe-application-design/SKILL.md).
-> It walks you from problem statement through privacy model, feasibility, scheme
-> selection, circuit design, SIMD data layout, and parameter selection. Copying an
+> **Building an FHE app? Follow the design skill first — do not skip the design
+> stages.** Before you write a single `.niob` file, install the
+> `fhe-application-design` skill (`make sync-skill` at the repository root; it
+> lands in `../.claude/skills/` and `../.agents/skills/` and auto-loads once
+> installed). It walks you from problem statement through privacy model,
+> feasibility, scheme selection, circuit design, SIMD data layout, and
+> parameter selection. Copying an
 > example without doing this design work is the most common way to ship a
 > working-but-wrong FHE application. This file (design rationale + codegen
 > internals) is *reference*, not the starting point.
@@ -26,7 +28,7 @@ make set-membership         # Build the private name-matching example
 
 | File | Purpose |
 |---|---|
-| **`../.claude/skills/fhe-application-design/SKILL.md`** | **START HERE for a new app** — 8-stage design guide (privacy model → feasibility → scheme → circuit → data layout → parameters → codegen). Read before writing `.niob`. |
+| **`fhe-application-design` skill** (install: `make sync-skill` at the repo root) | **START HERE for a new app** — staged design guide (privacy model → feasibility → scheme → circuit → data layout → parameters → implementation). Follow before writing `.niob`. |
 | `AGENTS.md` | This file — design rationale, codegen internals, known pitfalls (imported by `CLAUDE.md`, or read directly by non-Claude agents) |
 | `HOWTO.md` | Step-by-step guide for adding a new example |
 | `NB_LANGUAGE.md` | Language reference — types, syntax, built-in functions, patterns |

--- a/dsl_fhe/CLAUDE.md
+++ b/dsl_fhe/CLAUDE.md
@@ -1,9 +1,11 @@
 # CLAUDE.md
 
-> **Building an FHE app with this DSL? STOP and read
-> [`../.claude/skills/fhe-application-design/SKILL.md`](../.claude/skills/fhe-application-design/SKILL.md)
-> first.** It is an 8-stage design guide (privacy model → feasibility → scheme →
-> circuit → data layout → parameters → codegen). Do not skip the design stages and
+> **Building an FHE app with this DSL? STOP and follow the
+> `fhe-application-design` skill first** (install: `make sync-skill` at the
+> repository root; it lands in `../.claude/skills/` and `../.agents/skills/`
+> and auto-loads once installed). It is a staged design guide (privacy model →
+> feasibility → scheme → circuit → data layout → parameters → implementation).
+> Do not skip the design stages and
 > jump straight to copying an example — that is the most common way to get a
 > working-but-wrong FHE application.
 

--- a/dsl_fhe/README.md
+++ b/dsl_fhe/README.md
@@ -4,11 +4,13 @@ A domain-specific language and cross-compiler for writing Fully Homomorphic Encr
 applications. The DSL compiles `.niob` source files to C++ with openFHE, producing
 self-contained binaries for a client-server FHE pipeline.
 
-> **Designing a new app? Load the design skill first.** Before writing `.niob`,
-> read [`../.claude/skills/fhe-application-design/SKILL.md`](../.claude/skills/fhe-application-design/SKILL.md)
-> — an 8-stage guide from problem statement through privacy model, feasibility,
-> scheme selection, circuit design, data layout, and parameter selection. The DSL
-> is how you *express* an FHE app; the skill is how you *design* one correctly.
+> **Designing a new app? Install the design skill first.** Before writing
+> `.niob`, run `make sync-skill` at the repository root to install the
+> `fhe-application-design` skill (into `../.claude/skills/` and
+> `../.agents/skills/`; it auto-loads once installed) — a staged guide from
+> problem statement through privacy model, feasibility, scheme selection,
+> circuit design, data layout, and parameter selection. The DSL is how you
+> *express* an FHE app; the skill is how you *design* one correctly.
 
 ## Motivation
 


### PR DESCRIPTION
1. Update the Fog Quickstart section of the README to direct a user to use the AI skill to build their first FHE application
2. Update stale references to the old embedded skill to direct agents and users to install and use the skill