### PR TITLE
Optimizations to Example Workloads for Fog Quickstart flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ plaintext_add_keys/
 plaintext_add_server_workload_*/
 simple_ops_keys/
 simple_ops_server_workload_*/
+nbcc_fhetch_replay_source_*/
 
 # Reference material (scratch dirs at the repo root)
 /references/

--- a/Makefile
+++ b/Makefile
@@ -656,6 +656,7 @@ clean: ## Remove all build artifacts
 	-rm -rf $(OPENFHE_DIR)/build $(OPENFHE_DIR)/dbuild
 	-rm -rf bootstrap_keys mult_keys simple_ops_keys plaintext_add_keys
 	-rm -rf bootstrap_server_* mult_server_* simple_ops_server_* plaintext_add_server_*
+	-rm -rf nbcc_fhetch_replay_source_*
 
 clean-all: clean ## Deep clean including vendor installations
 	-rm -rf $(VENDOR_LIB_DIR)

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ fog list                                    # confirms auth (an empty list is fi
 ```bash
 cd build/examples
 ./mult_client mult_keys 7 13 65536          # creates mult_keys/, generates keys, encrypts (ring dimension 2^16)
-fog submit ./mult_server mult_keys --target=FOG
+fog submit ./mult_server mult_keys --hollow --target=FOG
 fog list                                    # watch your jobs
 ./mult_decrypt mult_keys                    # decrypt the results
 ```
@@ -452,7 +452,8 @@ generates keys and encrypts two integers, the server multiplies them on a Fog
 worker, and decrypt reveals the product. `mult_client`'s last argument is the ring 
 dimension (`65536` = 2^16); the two integers before it are the operands. 
 `fog submit` wraps `mult_server` so its `replay()` dispatches to the assigned worker 
-instead of the local simulator.
+instead of the local simulator. `--hollow` records the instruction trace without 
+computing the result on your machine; the Fog does the real math.
 
 ### 6. Use the Niobium skill to design and create your own FHE application
 

--- a/examples/auto/ciphers_ops_cache_keys.cpp
+++ b/examples/auto/ciphers_ops_cache_keys.cpp
@@ -44,7 +44,7 @@ int main(int argc, char* argv[]) {
     const auto size = static_cast<InstanceSize>(std::stoi(argv[1]));
     InstanceParams prms(size);
 
-    int multiplicative_depth = 3;
+    int multiplicative_depth = 2;  // chained ct*ct multiplies supported; MUL_MUL uses two
     if (argc > 2 && std::isdigit(argv[2][0]))
         multiplicative_depth = std::stoi(argv[2]);
 

--- a/examples/bootstrap/client.cpp
+++ b/examples/bootstrap/client.cpp
@@ -8,7 +8,8 @@
 //
 // This file is pure OpenFHE — no Niobium compiler dependency.
 //
-// Usage: ./bootstrap_client [output_dir]
+// Usage: ./bootstrap_client [output_dir [ring_dim]]
+//   Defaults: output_dir=bootstrap_keys, ring_dim=2048
 
 #include "openfhe.h"
 
@@ -23,7 +24,9 @@ using namespace lbcrypto;
 
 int main(int argc, char* argv[]) {
     std::string outputDir = "bootstrap_keys";
+    uint32_t ring_dim = 2048;
     if (argc > 1) outputDir = argv[1];
+    if (argc > 2) ring_dim = static_cast<uint32_t>(std::stoul(argv[2]));
 
     std::cout << "=== CKKS Bootstrap — Client (Key Generation) ===" << std::endl;
     std::cout << "Output directory: " << outputDir << std::endl;
@@ -35,7 +38,10 @@ int main(int argc, char* argv[]) {
     CCParams<CryptoContextCKKSRNS> parameters;
     parameters.SetSecretKeyDist(UNIFORM_TERNARY);
     parameters.SetSecurityLevel(HEStd_NotSet);
-    parameters.SetRingDim(2048);
+    // Polynomial ring size. Bootstrap keygen scales steeply with it: rotation
+    // keys for N/2 slots across the full ~24-level chain reach multiple GB and
+    // minutes of keygen at 2^16.
+    parameters.SetRingDim(ring_dim);
     parameters.SetScalingModSize(59);
     parameters.SetScalingTechnique(FLEXIBLEAUTO);
     parameters.SetFirstModSize(60);

--- a/examples/mult/client.cpp
+++ b/examples/mult/client.cpp
@@ -36,14 +36,14 @@ int main(int argc, char* argv[]) {
 
     std::filesystem::create_directories(outputDir);
 
-    // ---- CKKS parameters (matching compiler's TOY defaults) ----
+    // ---- CKKS parameters ----
     CCParams<CryptoContextCKKSRNS> parameters;
-    parameters.SetSecurityLevel(HEStd_NotSet);
-    parameters.SetRingDim(ring_dim);
-    parameters.SetMultiplicativeDepth(3);
-    parameters.SetScalingModSize(42);
-    parameters.SetFirstModSize(57);
-    parameters.SetScalingTechnique(FLEXIBLEAUTO);
+    parameters.SetSecurityLevel(HEStd_NotSet);     // no HE-standard security check (demo parameters)
+    parameters.SetRingDim(ring_dim);               // polynomial ring size; the Fog runs 2^16
+    parameters.SetMultiplicativeDepth(1);          // chained ct*ct multiplies supported; this circuit uses one
+    parameters.SetScalingModSize(42);              // bits of scale consumed by each multiply
+    parameters.SetFirstModSize(57);                // bits of the last modulus standing at decrypt
+    parameters.SetScalingTechnique(FLEXIBLEAUTO);  // rescale automatically after each multiply
 
     CryptoContext<DCRTPoly> cc = GenCryptoContext(parameters);
     cc->Enable(PKE);
@@ -56,10 +56,6 @@ int main(int argc, char* argv[]) {
     // ---- Key generation ----
     auto keyPair = cc->KeyGen();
     cc->EvalMultKeyGen(keyPair.secretKey);
-    // Generate a minimal rotation key set so the server can exercise the
-    // evalautomorphism-key loading path (matches the compiler reference,
-    // which always ships with rotation keys regardless of operation).
-    cc->EvalRotateKeyGen(keyPair.secretKey, {1, -1});
 
     // ---- Serialize crypto context + keys ----
     if (!Serial::SerializeToFile(outputDir + "/cc.bin", cc, SerType::BINARY))
@@ -73,11 +69,6 @@ int main(int argc, char* argv[]) {
     if (!mkStream.is_open() || !cc->SerializeEvalMultKey(mkStream, SerType::BINARY))
         throw std::runtime_error("Failed to serialize eval mult key");
     mkStream.close();
-
-    std::ofstream rkStream(outputDir + "/rk.bin", std::ios::out | std::ios::binary);
-    if (!rkStream.is_open() || !cc->SerializeEvalAutomorphismKey(rkStream, SerType::BINARY))
-        throw std::runtime_error("Failed to serialize eval automorphism key");
-    rkStream.close();
 
     // ---- Encrypt inputs ----
     std::vector<double> va = {a};

--- a/examples/mult/server.cpp
+++ b/examples/mult/server.cpp
@@ -110,6 +110,7 @@ int main(int argc, char* argv[]) {
     Ciphertext<DCRTPoly> ct_result;
     if (niobium::compiler().result(cc, "result", ct_result)) {
         // ---- Differential: compare simulator output vs OpenFHE's own EvalMult result ----
+        // Both sides are the Compress()ed single-tower result.
         auto compare_func = [](Ciphertext<DCRTPoly>& ct_openfhe_, Ciphertext<DCRTPoly>& ct_result_){
         
             std::cout << "\n--- Differential: simulator vs OpenFHE ---" << std::endl;

--- a/examples/mult/server.cpp
+++ b/examples/mult/server.cpp
@@ -65,15 +65,6 @@ int main(int argc, char* argv[]) {
             std::cout << "Loaded eval mult key" << std::endl;
         }
     }
-    {
-        std::ifstream rkStream(keyDir + "/rk.bin", std::ios::in | std::ios::binary);
-        if (rkStream.is_open()) {
-            if (!cc->DeserializeEvalAutomorphismKey(rkStream, SerType::BINARY))
-                throw std::runtime_error("Failed to load eval automorphism key");
-            std::cout << "Loaded eval automorphism key" << std::endl;
-        }
-    }
-
     // ---- Capture crypto context and tag polys for simulator ----
     // Address allocation is lazy (matches compiler's compact_address):
     // poly IDs exist from deserialization but only get FHETCH addresses
@@ -89,15 +80,23 @@ int main(int argc, char* argv[]) {
 
     if (!niobium::compiler().is_cache_valid()) {
         // ---- RECORDING PHASE ----
-        std::cout << "\n--- Recording EvalMult ---" << std::endl;
+        const bool hollow = niobium::compiler().is_hollow_mode();  // set by --hollow
+        std::cout << "\n--- Recording EvalMult ("
+                  << (hollow ? "hollow" : "real") << " mode) ---" << std::endl;
+        niobium::compiler().enable_hollow_mode(hollow);
         niobium::compiler().start();
 
-        auto ct_result = cc->EvalMult(ct_a, ct_b);
+        // Compress to one tower: decrypt needs only the last tower, and the
+        // compressed ciphertext is what travels back from a remote worker.
+        auto ct_result = cc->Compress(cc->EvalMult(ct_a, ct_b), 1);
 
         niobium::compiler().probe("result", ct_result);
         niobium::compiler().stop();
+        niobium::compiler().enable_hollow_mode(false);  // replay does real math
 
-        ct_openfhe = ct_result;  // stash for diff after replay
+        // A hollow record holds placeholder values, so there is no reference to diff.
+        if (!hollow)
+            ct_openfhe = ct_result;  // stash for diff after replay
     }
 
     // ---- REPLAY: execute trace through the FHETCH simulator ----

--- a/examples/plaintext_add/client.cpp
+++ b/examples/plaintext_add/client.cpp
@@ -8,7 +8,8 @@
 //
 // This file is pure OpenFHE — no Niobium compiler dependency.
 //
-// Usage: ./plaintext_add_client [output_dir]
+// Usage: ./plaintext_add_client [output_dir [ring_dim]]
+//   Defaults: output_dir=plaintext_add_keys, ring_dim=2048
 
 #include "openfhe.h"
 
@@ -23,7 +24,9 @@ using namespace lbcrypto;
 
 int main(int argc, char* argv[]) {
     std::string outputDir = "plaintext_add_keys";
+    uint32_t ring_dim = 2048;
     if (argc > 1) outputDir = argv[1];
+    if (argc > 2) ring_dim = static_cast<uint32_t>(std::stoul(argv[2]));
 
     std::cout << "=== CKKS Plaintext-Add — Client (Key Generation) ===" << std::endl;
     std::cout << "Output directory: " << outputDir << std::endl;
@@ -34,7 +37,7 @@ int main(int argc, char* argv[]) {
     CCParams<CryptoContextCKKSRNS> parameters;
     parameters.SetSecretKeyDist(UNIFORM_TERNARY);  // secret-key coefficient distribution
     parameters.SetSecurityLevel(HEStd_NotSet);     // no HE-standard security check (demo parameters)
-    parameters.SetRingDim(2048);                   // polynomial ring size (toy; local sim only)
+    parameters.SetRingDim(ring_dim);               // polynomial ring size; the Fog runs 2^16
     parameters.SetScalingModSize(59);              // bits of scale consumed by each multiply
     parameters.SetScalingTechnique(FLEXIBLEAUTO);  // rescale automatically after each multiply
     parameters.SetFirstModSize(60);                // bits of the last modulus standing at decrypt

--- a/examples/plaintext_add/client.cpp
+++ b/examples/plaintext_add/client.cpp
@@ -32,13 +32,13 @@ int main(int argc, char* argv[]) {
 
     // ---- CKKS parameters ----
     CCParams<CryptoContextCKKSRNS> parameters;
-    parameters.SetSecretKeyDist(UNIFORM_TERNARY);
-    parameters.SetSecurityLevel(HEStd_NotSet);
-    parameters.SetRingDim(2048);
-    parameters.SetScalingModSize(59);
-    parameters.SetScalingTechnique(FLEXIBLEAUTO);
-    parameters.SetFirstModSize(60);
-    parameters.SetMultiplicativeDepth(2);
+    parameters.SetSecretKeyDist(UNIFORM_TERNARY);  // secret-key coefficient distribution
+    parameters.SetSecurityLevel(HEStd_NotSet);     // no HE-standard security check (demo parameters)
+    parameters.SetRingDim(2048);                   // polynomial ring size (toy; local sim only)
+    parameters.SetScalingModSize(59);              // bits of scale consumed by each multiply
+    parameters.SetScalingTechnique(FLEXIBLEAUTO);  // rescale automatically after each multiply
+    parameters.SetFirstModSize(60);                // bits of the last modulus standing at decrypt
+    parameters.SetMultiplicativeDepth(1);          // chained ct*ct multiplies supported; this circuit uses none
 
     CryptoContext<DCRTPoly> cc = GenCryptoContext(parameters);
     cc->Enable(PKE);

--- a/examples/plaintext_add/server.cpp
+++ b/examples/plaintext_add/server.cpp
@@ -70,13 +70,19 @@ int main(int argc, char* argv[]) {
     niobium::compiler().tag_input("input_plaintext", pt);
 
     if (!niobium::compiler().is_cache_valid()) {
-        std::cout << "\n--- Recording plaintext-add ---" << std::endl;
+        const bool hollow = niobium::compiler().is_hollow_mode();  // set by --hollow
+        std::cout << "\n--- Recording plaintext-add ("
+                  << (hollow ? "hollow" : "real") << " mode) ---" << std::endl;
+        niobium::compiler().enable_hollow_mode(hollow);
         niobium::compiler().start();
 
-        auto ciphertextAfter = cc->EvalAdd(ciph, pt);
+        // Compress to one tower: decrypt needs only the last tower, and the
+        // compressed ciphertext is what travels back from a remote worker.
+        auto ciphertextAfter = cc->Compress(cc->EvalAdd(ciph, pt), 1);
 
         niobium::compiler().probe("output_cipher", ciphertextAfter);
         niobium::compiler().stop();
+        niobium::compiler().enable_hollow_mode(false);  // replay does real math
     }
 
     // ---- REPLAY: execute trace through the FHETCH simulator ----

--- a/examples/simple_ops/client.cpp
+++ b/examples/simple_ops/client.cpp
@@ -6,7 +6,8 @@
 // Generates CKKS crypto context + keys, encrypts two values.
 // Matching compiler's TOY defaults: qi=42, firstMod=57, N=2048, depth=2.
 //
-// Usage: ./simple_ops_client [output_dir [a b]]
+// Usage: ./simple_ops_client [output_dir [a [b [ring_dim]]]]
+//   Defaults: output_dir=simple_ops_keys, a=5.0, b=6.0, ring_dim=2048
 
 #include "openfhe.h"
 
@@ -22,10 +23,12 @@ using namespace lbcrypto;
 int main(int argc, char* argv[]) {
     std::string outputDir = "simple_ops_keys";
     double a = 5.0, b = 6.0;
+    uint32_t ring_dim = 2048;
 
     if (argc > 1) outputDir = argv[1];
     if (argc > 2) a = std::stod(argv[2]);
     if (argc > 3) b = std::stod(argv[3]);
+    if (argc > 4) ring_dim = static_cast<uint32_t>(std::stoul(argv[4]));
 
     std::cout << "=== Simple Ops — Client ===" << std::endl;
     std::cout << "a = " << a << ", b = " << b << std::endl;
@@ -34,7 +37,7 @@ int main(int argc, char* argv[]) {
 
     CCParams<CryptoContextCKKSRNS> parameters;
     parameters.SetSecurityLevel(HEStd_NotSet);     // no HE-standard security check (demo parameters)
-    parameters.SetRingDim(2048);                   // polynomial ring size (toy; local sim only)
+    parameters.SetRingDim(ring_dim);               // polynomial ring size; the Fog runs 2^16
     parameters.SetMultiplicativeDepth(2);          // chained ct*ct multiplies supported; MUL_MUL uses two
     parameters.SetScalingModSize(42);              // bits of scale consumed by each multiply
     parameters.SetFirstModSize(57);                // bits of the last modulus standing at decrypt

--- a/examples/simple_ops/client.cpp
+++ b/examples/simple_ops/client.cpp
@@ -33,12 +33,12 @@ int main(int argc, char* argv[]) {
     std::filesystem::create_directories(outputDir);
 
     CCParams<CryptoContextCKKSRNS> parameters;
-    parameters.SetSecurityLevel(HEStd_NotSet);
-    parameters.SetRingDim(2048);
-    parameters.SetMultiplicativeDepth(3);
-    parameters.SetScalingModSize(42);
-    parameters.SetFirstModSize(57);
-    parameters.SetScalingTechnique(FLEXIBLEAUTO);
+    parameters.SetSecurityLevel(HEStd_NotSet);     // no HE-standard security check (demo parameters)
+    parameters.SetRingDim(2048);                   // polynomial ring size (toy; local sim only)
+    parameters.SetMultiplicativeDepth(2);          // chained ct*ct multiplies supported; MUL_MUL uses two
+    parameters.SetScalingModSize(42);              // bits of scale consumed by each multiply
+    parameters.SetFirstModSize(57);                // bits of the last modulus standing at decrypt
+    parameters.SetScalingTechnique(FLEXIBLEAUTO);  // rescale automatically after each multiply
 
     CryptoContext<DCRTPoly> cc = GenCryptoContext(parameters);
     cc->Enable(PKE);

--- a/examples/simple_ops/client.cpp
+++ b/examples/simple_ops/client.cpp
@@ -55,14 +55,19 @@ int main(int argc, char* argv[]) {
     cc->EvalRotateKeyGen(keyPair.secretKey, {1, -1});
 
     // Serialize
-    Serial::SerializeToFile(outputDir + "/cc.bin", cc, SerType::BINARY);
-    Serial::SerializeToFile(outputDir + "/pk.bin", keyPair.publicKey, SerType::BINARY);
-    Serial::SerializeToFile(outputDir + "/sk.bin", keyPair.secretKey, SerType::BINARY);
+    if (!Serial::SerializeToFile(outputDir + "/cc.bin", cc, SerType::BINARY))
+        throw std::runtime_error("Failed to serialize crypto context");
+    if (!Serial::SerializeToFile(outputDir + "/pk.bin", keyPair.publicKey, SerType::BINARY))
+        throw std::runtime_error("Failed to serialize public key");
+    if (!Serial::SerializeToFile(outputDir + "/sk.bin", keyPair.secretKey, SerType::BINARY))
+        throw std::runtime_error("Failed to serialize secret key");
     std::ofstream mkStream(outputDir + "/mk.bin", std::ios::binary);
-    cc->SerializeEvalMultKey(mkStream, SerType::BINARY);
+    if (!mkStream.is_open() || !cc->SerializeEvalMultKey(mkStream, SerType::BINARY))
+        throw std::runtime_error("Failed to serialize eval mult key");
     mkStream.close();
     std::ofstream rkStream(outputDir + "/rk.bin", std::ios::binary);
-    cc->SerializeEvalAutomorphismKey(rkStream, SerType::BINARY);
+    if (!rkStream.is_open() || !cc->SerializeEvalAutomorphismKey(rkStream, SerType::BINARY))
+        throw std::runtime_error("Failed to serialize eval automorphism key");
     rkStream.close();
 
     // Pack two slots in ct_a so rotations produce a non-trivial result:
@@ -72,8 +77,10 @@ int main(int argc, char* argv[]) {
     auto ct_a = cc->Encrypt(keyPair.publicKey, cc->MakeCKKSPackedPlaintext(va));
     auto ct_b = cc->Encrypt(keyPair.publicKey, cc->MakeCKKSPackedPlaintext(vb));
 
-    Serial::SerializeToFile(outputDir + "/ct_a.bin", ct_a, SerType::BINARY);
-    Serial::SerializeToFile(outputDir + "/ct_b.bin", ct_b, SerType::BINARY);
+    if (!Serial::SerializeToFile(outputDir + "/ct_a.bin", ct_a, SerType::BINARY))
+        throw std::runtime_error("Failed to serialize ciphertext a");
+    if (!Serial::SerializeToFile(outputDir + "/ct_b.bin", ct_b, SerType::BINARY))
+        throw std::runtime_error("Failed to serialize ciphertext b");
 
     std::ofstream valStream(outputDir + "/values.txt");
     valStream << a << " " << b << std::endl;

--- a/examples/simple_ops/server.cpp
+++ b/examples/simple_ops/server.cpp
@@ -63,6 +63,8 @@ int main(int argc, char* argv[]) {
 
     // Load only the keys this operation uses — tag_keys() ships whatever the
     // context holds, so loading nothing extra uploads nothing extra.
+    // Only ct*ct multiplies need the relinearization key; scalar EvalMult
+    // (MULI, ALL_NO_MUL) does not.
     const bool needs_mult_key = operation == "MUL" || operation == "MUL_ADD" ||
                                 operation == "ADD_MUL" || operation == "MUL_MUL";
     const bool needs_rotation_key = operation == "MORPH";
@@ -86,6 +88,7 @@ int main(int argc, char* argv[]) {
     niobium::compiler().capture_crypto_context(cc);
     niobium::compiler().tag_input("ct_a", ct_a);
     niobium::compiler().tag_input("ct_b", ct_b);
+    // A session with no eval keys is valid (plaintext_add never tags any).
     if (has_mult_key || has_rotation_key)
         niobium::compiler().tag_keys(cc);
 
@@ -174,6 +177,7 @@ int main(int argc, char* argv[]) {
     Ciphertext<DCRTPoly> ct_result;
     if (niobium::compiler().result(cc, "result", ct_result)) {
         if (ct_openfhe) {
+            // Both sides are the Compress()ed single-tower result.
             std::cout << "\n--- Differential: simulator vs OpenFHE ---" << std::endl;
             const auto& oe = ct_openfhe->GetElements();
             const auto& sm = ct_result->GetElements();

--- a/examples/simple_ops/server.cpp
+++ b/examples/simple_ops/server.cpp
@@ -61,33 +61,43 @@ int main(int argc, char* argv[]) {
     if (!Serial::DeserializeFromFile(keyDir + "/ct_b.bin", ct_b, SerType::BINARY))
         throw std::runtime_error("Failed to load ciphertext b");
 
+    // Load only the keys this operation uses — tag_keys() ships whatever the
+    // context holds, so loading nothing extra uploads nothing extra.
+    const bool needs_mult_key = operation == "MUL" || operation == "MUL_ADD" ||
+                                operation == "ADD_MUL" || operation == "MUL_MUL";
+    const bool needs_rotation_key = operation == "MORPH";
     bool has_mult_key = false;
-    {
+    if (needs_mult_key) {
         std::ifstream mkStream(keyDir + "/mk.bin", std::ios::binary);
         if (mkStream.is_open()) {
             if (cc->DeserializeEvalMultKey(mkStream, SerType::BINARY))
                 has_mult_key = true;
         }
     }
-    {
+    bool has_rotation_key = false;
+    if (needs_rotation_key) {
         std::ifstream rkStream(keyDir + "/rk.bin", std::ios::binary);
-        if (rkStream.is_open())
-            cc->DeserializeEvalAutomorphismKey(rkStream, SerType::BINARY);
+        if (rkStream.is_open() &&
+            cc->DeserializeEvalAutomorphismKey(rkStream, SerType::BINARY))
+            has_rotation_key = true;
     }
 
     // ---- Capture crypto context and tag polys ----
     niobium::compiler().capture_crypto_context(cc);
     niobium::compiler().tag_input("ct_a", ct_a);
     niobium::compiler().tag_input("ct_b", ct_b);
-    if (has_mult_key)
+    if (has_mult_key || has_rotation_key)
         niobium::compiler().tag_keys(cc);
 
     // Saved copy of OpenFHE's own computed result — diffed against the
     // simulator's output after replay.
     Ciphertext<DCRTPoly> ct_openfhe;
 
+    const bool hollow = niobium::compiler().is_hollow_mode();  // set by --hollow
     if (!niobium::compiler().is_cache_valid()) {
-        std::cout << "\n--- Recording " << operation << " ---" << std::endl;
+        std::cout << "\n--- Recording " << operation << " ("
+                  << (hollow ? "hollow" : "real") << " mode) ---" << std::endl;
+        niobium::compiler().enable_hollow_mode(hollow);
         niobium::compiler().start();
 
         Ciphertext<DCRTPoly> result;
@@ -141,9 +151,16 @@ int main(int argc, char* argv[]) {
             return 1;
         }
 
+        // Compress to one tower: decrypt needs only the last tower, and the
+        // compressed ciphertext is what travels back from a remote worker.
+        result = cc->Compress(result, 1);
+
         niobium::compiler().probe("result", result);
         niobium::compiler().stop();
-        ct_openfhe = result;
+        niobium::compiler().enable_hollow_mode(false);  // replay does real math
+        // A hollow record holds placeholder values, so there is no reference to diff.
+        if (!hollow)
+            ct_openfhe = result;
     }
 
     // ---- Replay ----

--- a/examples/simple_ops/server.cpp
+++ b/examples/simple_ops/server.cpp
@@ -68,28 +68,24 @@ int main(int argc, char* argv[]) {
     const bool needs_mult_key = operation == "MUL" || operation == "MUL_ADD" ||
                                 operation == "ADD_MUL" || operation == "MUL_MUL";
     const bool needs_rotation_key = operation == "MORPH";
-    bool has_mult_key = false;
     if (needs_mult_key) {
         std::ifstream mkStream(keyDir + "/mk.bin", std::ios::binary);
-        if (mkStream.is_open()) {
-            if (cc->DeserializeEvalMultKey(mkStream, SerType::BINARY))
-                has_mult_key = true;
-        }
+        if (mkStream.is_open())
+            cc->DeserializeEvalMultKey(mkStream, SerType::BINARY);
     }
-    bool has_rotation_key = false;
     if (needs_rotation_key) {
         std::ifstream rkStream(keyDir + "/rk.bin", std::ios::binary);
-        if (rkStream.is_open() &&
-            cc->DeserializeEvalAutomorphismKey(rkStream, SerType::BINARY))
-            has_rotation_key = true;
+        if (rkStream.is_open())
+            cc->DeserializeEvalAutomorphismKey(rkStream, SerType::BINARY);
     }
 
     // ---- Capture crypto context and tag polys ----
     niobium::compiler().capture_crypto_context(cc);
     niobium::compiler().tag_input("ct_a", ct_a);
     niobium::compiler().tag_input("ct_b", ct_b);
-    // A session with no eval keys is valid (plaintext_add never tags any).
-    if (has_mult_key || has_rotation_key)
+    // Keyless sessions are valid: tag_keys only serializes eval keys; context
+    // metadata comes from capture_crypto_context.
+    if (needs_mult_key || needs_rotation_key)
         niobium::compiler().tag_keys(cc);
 
     // Saved copy of OpenFHE's own computed result — diffed against the


### PR DESCRIPTION
Aggregate improvements across example workloads:
- Walltime reduced by 22%
- Upload size reduced by 67%
- Download size reduced by 75%

Changes
- Keys are generated at each circuit's minimum depth: `mult` 3→1, `simple_ops` 3→2, `plaintext_add` 2→1, auto default 3→2. `mult` stops generating rotation keys its circuit never uses.
- `simple_ops` loads and tags only the keys the selected operation uses; add ships no eval keys at all.
- Servers `Compress` the result to one tower inside the recorded circuit.
- `--hollow` now engages hollow recording around the record pass and skips the OpenFHE differential, which has no real reference under hollow. The README Quick start’s sample job passes --hollow.
- The example clients (`simple_ops`, `plaintext_add`, `bootstrap`) take the trailing optional `ring_dim` argument `mult` already has, defaults unchanged at 2048.
- Transport replay staging dirs (`nbcc_fhetch_replay_source_*`) are gitignored and removed by `make clean`.

The test targets and CI never pass `--hollow`, so the OpenFHE reference comparison (the per-example differential and `test_transport_mult.sh`'s byte-identity check) still records real math and passes unchanged.