### PR TITLE
Use tools that exist on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,10 @@ UNAME_S := $(shell uname -s)
 
 ifndef NUM_CPUS
   ifeq ($(UNAME_S), Darwin)
-    NUM_CPUS := $(shell sysctl -n hw.ncpu)
+    NUM_CPUS := $(shell sysctl -n hw.ncpu 2>/dev/null || /usr/sbin/sysctl -n hw.ncpu 2>/dev/null || echo 4)
     export DYLD_LIBRARY_PATH := $(CURDIR)/vendor/lib/openfhe/lib:$(DYLD_LIBRARY_PATH)
   else
-    NUM_CPUS := $(shell nproc)
+    NUM_CPUS := $(shell nproc 2>/dev/null || echo 4)
     export LD_LIBRARY_PATH := $(CURDIR)/vendor/lib/openfhe/lib:$(LD_LIBRARY_PATH)
   endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -30,14 +30,16 @@ SHELL := /bin/bash
 
 UNAME_S := $(shell uname -s)
 
+include make/platform.mk
+
 ifndef NUM_CPUS
-  ifeq ($(UNAME_S), Darwin)
-    NUM_CPUS := $(shell sysctl -n hw.ncpu 2>/dev/null || /usr/sbin/sysctl -n hw.ncpu 2>/dev/null || echo 4)
-    export DYLD_LIBRARY_PATH := $(CURDIR)/vendor/lib/openfhe/lib:$(DYLD_LIBRARY_PATH)
-  else
-    NUM_CPUS := $(shell nproc 2>/dev/null || echo 4)
-    export LD_LIBRARY_PATH := $(CURDIR)/vendor/lib/openfhe/lib:$(LD_LIBRARY_PATH)
-  endif
+  NUM_CPUS := $(NB_NUM_CPUS)
+endif
+
+ifeq ($(UNAME_S), Darwin)
+  export DYLD_LIBRARY_PATH := $(CURDIR)/vendor/lib/openfhe/lib:$(DYLD_LIBRARY_PATH)
+else
+  export LD_LIBRARY_PATH := $(CURDIR)/vendor/lib/openfhe/lib:$(LD_LIBRARY_PATH)
 endif
 
 # ==============================================================================

--- a/dsl_fhe/Makefile
+++ b/dsl_fhe/Makefile
@@ -1,7 +1,8 @@
 XCOMP     := xcomp
 NBC       := python3 -m xcomp.nbc
 EXAMPLES  := examples
-NPROC     := $(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+include ../make/platform.mk
+NPROC     := $(NB_NUM_CPUS)
 
 # Root of the niobium-client checkout (holds vendor/lib/openfhe and the built
 # libnbfhetch). dsl_fhe lives directly under it.

--- a/make/platform.mk
+++ b/make/platform.mk
@@ -1,12 +1,8 @@
 # Host detection, shared by the root Makefile and dsl_fhe/Makefile so the two
 # cannot drift apart.
 #
-# nproc is coreutils and absent on macOS; sysctl lives in /usr/sbin, which is not
-# always on PATH, so it is also tried by absolute path. Falling back to a literal
-# matters: an empty value would turn `-j $(NB_NUM_CPUS)` into unbounded
-# parallelism rather than an error.
+# getconf is in /usr/bin on both Linux and macOS and needs no coreutils, unlike
+# nproc, and no /usr/sbin on PATH, unlike sysctl. The literal fallback matters:
+# an empty value would turn `-j $(NB_NUM_CPUS)` into unbounded parallelism.
 
-NB_NUM_CPUS := $(shell nproc 2>/dev/null \
-	|| sysctl -n hw.ncpu 2>/dev/null \
-	|| /usr/sbin/sysctl -n hw.ncpu 2>/dev/null \
-	|| echo 4)
+NB_NUM_CPUS := $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)

--- a/make/platform.mk
+++ b/make/platform.mk
@@ -1,0 +1,12 @@
+# Host detection, shared by the root Makefile and dsl_fhe/Makefile so the two
+# cannot drift apart.
+#
+# nproc is coreutils and absent on macOS; sysctl lives in /usr/sbin, which is not
+# always on PATH, so it is also tried by absolute path. Falling back to a literal
+# matters: an empty value would turn `-j $(NB_NUM_CPUS)` into unbounded
+# parallelism rather than an error.
+
+NB_NUM_CPUS := $(shell nproc 2>/dev/null \
+	|| sysctl -n hw.ncpu 2>/dev/null \
+	|| /usr/sbin/sysctl -n hw.ncpu 2>/dev/null \
+	|| echo 4)

--- a/scripts/test_transport_mult.sh
+++ b/scripts/test_transport_mult.sh
@@ -138,23 +138,32 @@ fi
 echo
 echo "decrypt PASS — continuing to binary comparison"
 
+# sha256sum is GNU coreutils; macOS ships shasum instead.
+sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$@"
+  else
+    shasum -a 256 "$@"
+  fi
+}
+
 echo
 echo "=== [5/5] binary comparison ==="
 # Compute the hashes of the result openfhe computed, the result our pipeline writes to the final destination,
 # the ciphertext template the compiler uses, and the serialized probe of the compiler
-OPENFHE_RESULT_HASH=$(sha256sum mult_keys/ct_result_openfhe.bin | awk '{print $1}')
+OPENFHE_RESULT_HASH=$(sha256 mult_keys/ct_result_openfhe.bin | awk '{print $1}')
 echo "OpenFHE Gold Standard"
 echo $OPENFHE_RESULT_HASH
 
-FINAL_RESULT_HASH=$(sha256sum mult_keys/ct_result.bin | awk '{print $1}') 
+FINAL_RESULT_HASH=$(sha256 mult_keys/ct_result.bin | awk '{print $1}') 
 echo "Compiler Pipeline Result"
 echo $FINAL_RESULT_HASH
 
-CT_TEMPLATE_HASH=$(sha256sum mult_server_workload_ckks_mult/ciphertext_templates/result.template | awk '{print $1}')
+CT_TEMPLATE_HASH=$(sha256 mult_server_workload_ckks_mult/ciphertext_templates/result.template | awk '{print $1}')
 echo "Compiler Internal Ciphertext Template"
 echo $CT_TEMPLATE_HASH
 
-CT_PROBE_HASH=$(sha256sum mult_server_workload_ckks_mult/serialized_probes/result.ct | awk '{print $1}')
+CT_PROBE_HASH=$(sha256 mult_server_workload_ckks_mult/serialized_probes/result.ct | awk '{print $1}')
 echo "Compiler Internal Serialized Probe"
 echo $CT_PROBE_HASH
 


### PR DESCRIPTION
Two GNU/Linux assumptions that fail on a Mac without extra tooling installed.

## `sha256sum`

`scripts/test_transport_mult.sh` hashes four artifacts with `sha256sum`, which is GNU coreutils and not present on macOS:

```
scripts/test_transport_mult.sh: line 145: sha256sum: command not found
make[2]: *** [Makefile:497: test-mult-transport-release] Error 127
```

The four call sites now go through a helper that prefers `sha256sum` and falls back to `shasum -a 256`. Both emit a plain SHA-256 digest in the same `<hex>  <file>` layout, so the surrounding `awk '{print $1}'` is untouched. Verified here that the digest `sha256sum` produces matches `openssl dgst -sha256` exactly, which is what makes the substitution safe.

## `sysctl`

`Makefile:35` read the core count with a bare `sysctl -n hw.ncpu`. That binary lives in `/usr/sbin`, which is not necessarily on `PATH` — and when the lookup fails, `NUM_CPUS` is left **empty**, so `-j $(NUM_CPUS)` becomes unbounded parallelism rather than an error. It now falls back the way `dsl_fhe/Makefile:4` in this repo already does, with `/usr/sbin/sysctl` tried explicitly before giving up on 4. The Linux branch gets the same treatment for its `nproc`.

## How these turned up

Running the niobium-compiler test suite on a Mac that does not carry the extra tooling a hosted GitHub runner image ships. The compiler's macOS CI leg is moving to a self-hosted Mac to get off a three-core hosted runner, and these were the first two things it hit — a hosted image has coreutils and a fuller `PATH`, so neither had ever been exercised.

Both fixes also matter outside CI: a developer on a stock macOS install hits the same `sha256sum: command not found` running the transport test today.
