### PR TITLE
Let the auto-facade choose the trace format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -503,7 +503,7 @@ test-mult-release: build-release ## Run the multiply example: client → server 
 NIOBIUM_COMPILER_ROOT ?= $(realpath $(CURDIR)/../..)
 TARGET ?= FUNC_SIM
 
-test-mult-target-release: build-release ## Run mult with --target=$(TARGET). Overrides: TARGET=FUNC_SIM|fpga5.2|…  NIOBIUM_COMPILER_ROOT=/path
+test-mult-target-release: build-release ## Run mult with --target=$(TARGET). Overrides: TARGET=FUNC_SIM|fpga5.2|…  NIOBIUM_COMPILER_ROOT=/path  TRACE_FORMAT=text|binary|both
 	$(call set-build-config,Release,build)
 	@if [ ! -x "$(NIOBIUM_COMPILER_ROOT)/build/nbcc_fhetch_replay" ]; then \
 		echo "ERROR: nbcc_fhetch_replay not found at $(NIOBIUM_COMPILER_ROOT)/build/nbcc_fhetch_replay"; \
@@ -517,7 +517,23 @@ test-mult-target-release: build-release ## Run mult with --target=$(TARGET). Ove
 	@echo "=== [2/3] mult_server --target=$(TARGET) (hollow record → dispatch to compiler) ==="
 	NBCC_FHETCH_REPLAY=$(NIOBIUM_COMPILER_ROOT)/build/nbcc_fhetch_replay \
 	$(RUN_WITHOUT_LIBRARY_PATH) \
-		$(BUILD_DIR)/examples/mult_server mult_keys --target=$(TARGET) --no-ring-dim-check
+		$(BUILD_DIR)/examples/mult_server mult_keys --target=$(TARGET) --no-ring-dim-check \
+		$(if $(TRACE_FORMAT),--trace-format=$(TRACE_FORMAT))
+	@if [ -n "$(TRACE_FORMAT)" ]; then \
+		t=$$(find mult_server_workload_* -name '*.fhetch' 2>/dev/null | wc -l | tr -d ' '); \
+		b=$$(find mult_server_workload_* -name '*.fhex' 2>/dev/null | wc -l | tr -d ' '); \
+		case "$(TRACE_FORMAT)" in \
+			text)   wt=1; wb=0 ;; \
+			binary) wt=0; wb=1 ;; \
+			both)   wt=1; wb=1 ;; \
+		esac; \
+		if [ "$$t" != "$$wt" ] || [ "$$b" != "$$wb" ]; then \
+			echo "  FAIL: --trace-format=$(TRACE_FORMAT) produced .fhetch=$$t .fhex=$$b," \
+			     "expected .fhetch=$$wt .fhex=$$wb"; \
+			exit 1; \
+		fi; \
+		echo "  trace artifacts OK (.fhetch=$$t .fhex=$$b)"; \
+	fi
 	@echo ""
 	@echo "=== [3/3] mult_decrypt ==="
 	$(BUILD_DIR)/examples/mult_decrypt mult_keys

--- a/Makefile
+++ b/Makefile
@@ -383,6 +383,48 @@ AUTO_B         ?= 3
 AUTO_IMM       ?= 0
 AUTO_EXPECTED  ?= 10
 
+test-auto-trace-format-release: build-release ## Auto-facade: --trace-format reaches the compiler through nbcc.py + YAML
+	$(call set-build-config,Release,build)
+	@rm -rf ciphers_auto_fmt
+	@mkdir -p ciphers_auto_fmt
+	@echo "=== keygen ==="
+	@cd ciphers_auto_fmt && LD_LIBRARY_PATH=$(OPENFHE_INSTALL_DIR)/lib \
+		$(CURDIR)/$(BUILD_DIR)/examples/ciphers_ops_cache_keys 0
+	@echo "=== encrypt ==="
+	@cd ciphers_auto_fmt && LD_LIBRARY_PATH=$(OPENFHE_INSTALL_DIR)/lib \
+		$(CURDIR)/$(BUILD_DIR)/examples/ciphers_ops_client 0 $(AUTO_A) $(AUTO_B) output_a.bin output_b.bin
+	@for fmt in text binary both; do \
+		echo ""; \
+		echo "=== record with --trace-format=$$fmt ==="; \
+		rm -rf ciphers_auto_fmt/auto_fmt_*; \
+		( cd ciphers_auto_fmt && LD_LIBRARY_PATH=$(OPENFHE_INSTALL_DIR)/lib \
+			python3 $(CURDIR)/tools/nbcc.py \
+			--name auto_fmt --cache wl=TOY --cache op=$(AUTO_OP) \
+			--keys-mult io/toy/keys/mk.bin --keys-auto io/toy/keys/rk.bin \
+			--no-ring-dim-check --trace-format=$$fmt \
+			-- \
+			$(CURDIR)/$(BUILD_DIR)/examples/ciphers_ops_server_auto 0 \
+			output_a.bin output_b.bin $(AUTO_EXPECTED) $(AUTO_OP) $(AUTO_IMM) ) \
+			> ciphers_auto_fmt/run_$$fmt.log 2>&1 \
+			|| { echo "  FAIL: record failed"; tail -20 ciphers_auto_fmt/run_$$fmt.log; exit 1; }; \
+		text_n=$$(find ciphers_auto_fmt -name '*.fhetch' | wc -l | tr -d ' '); \
+		bin_n=$$(find ciphers_auto_fmt -name '*.fhex' | wc -l | tr -d ' '); \
+		case "$$fmt" in \
+			text)   want_t=1; want_b=0 ;; \
+			binary) want_t=0; want_b=1 ;; \
+			both)   want_t=1; want_b=1 ;; \
+		esac; \
+		if [ "$$text_n" != "$$want_t" ] || [ "$$bin_n" != "$$want_b" ]; then \
+			echo "  FAIL: --trace-format=$$fmt produced .fhetch=$$text_n .fhex=$$bin_n," \
+			     "expected .fhetch=$$want_t .fhex=$$want_b"; \
+			exit 1; \
+		fi; \
+		grep -q "PASS\|MATCH\|correct" ciphers_auto_fmt/run_$$fmt.log \
+			|| { echo "  WARN: no success marker in run log"; }; \
+		echo "  OK: .fhetch=$$text_n .fhex=$$bin_n"; \
+	done
+	@echo "auto-facade trace-format: all three formats OK"
+
 test-auto-ciphers-release: build-release ## Auto-facade ciphers_ops: keygen → record → replay (no niobium:: in user code). Op/values overridable: AUTO_OP=... AUTO_A=... AUTO_B=... AUTO_IMM=... AUTO_EXPECTED=...
 	$(call set-build-config,Release,build)
 	@rm -rf ciphers_auto
@@ -644,7 +686,7 @@ test-transport-hardening-release: build-release ## Security regressions for the 
 	    $(if $(PROJECT),--project $(PROJECT),)
 
 ## Run all client-level Release tests (CI target — no fhetch submodule)
-test-client-release: test-simple-ops-release test-mult-release test-auto-ciphers-release test-bootstrap-release test-plaintext-add-release test-ring-dim-check-release test-transport-hardening-release
+test-client-release: test-simple-ops-release test-mult-release test-auto-ciphers-release test-auto-trace-format-release test-bootstrap-release test-plaintext-add-release test-ring-dim-check-release test-transport-hardening-release
 
 ## Run all currently-passing Release tests (client + fhetch submodule) — internal server only, do not run in CI
 test-release: test-client-release test-fhetch-release

--- a/README.md
+++ b/README.md
@@ -156,7 +156,10 @@ directly.
 
 3. **Capture** — On `compiler().stop()`, the trace is finalized as a `.fhetch`
    text file plus a `fhetch_replay.json` manifest (crypto context, modulus
-   chain, key ID ranges, input/output layout).
+   chain, key ID ranges, input/output layout). Pass
+   `--trace-format=binary` to write a `.fhex` instead — the same program in a
+   binary form roughly 4x smaller and faster to read — or
+   `--trace-format=both` for both. The default is text.
 
 4. **Replay (local)** — `compiler().replay()` executes the recorded trace
    through the bundled FHETCH simulator; `compiler().result(cc, name, ct)`

--- a/docs/AUTO_FACADE.md
+++ b/docs/AUTO_FACADE.md
@@ -106,6 +106,7 @@ keys:
 # All fields are optional; omitted fields use init() defaults.
 compiler:
   target:       FUNC_SIM       # FUNC_SIM | FHE_SIM | QEMU_SIM | FPGA1 | FPGA2
+  trace_format: binary         # --trace-format (text | binary | both)
   optimization: "3"            # -O level
   registers:    "32"           # --registers
   memory:       "16"           # --memory (GB)

--- a/src/auto_facade/AutoFacade.cpp
+++ b/src/auto_facade/AutoFacade.cpp
@@ -258,6 +258,7 @@ static std::vector<std::string> build_init_argv(const YAML::Node &node) {
   };
 
   add_value_flag("target", "--target");
+  add_value_flag("trace_format", "--trace-format");
   if (node["optimization"])
     args.push_back("-O" + node["optimization"].as<std::string>());
   add_value_flag("registers", "--registers");

--- a/tools/nbcc.py
+++ b/tools/nbcc.py
@@ -57,6 +57,7 @@ def build_yaml(args):
             compiler_lines.append(f"  {key}: {'true' if value else 'false'}")
 
     add_value("target", args.target)
+    add_value("trace_format", args.trace_format)
     add_value("optimization", args.optimization)
     add_value("registers", args.registers)
     add_value("memory", args.memory)
@@ -128,6 +129,11 @@ def parse_args():
     parser.add_argument("--target", default="local",
                         help="Target (default: local — in-process FHETCH sim; "
                              "non-local values dispatch to nbcc_fhetch_replay)")
+    parser.add_argument("--trace-format", default=None,
+                        choices=["text", "binary", "both"],
+                        help="Trace serialization: text (.fhetch, default), "
+                             "binary (.fhex, ~4x smaller and faster to read), "
+                             "or both")
     parser.add_argument("-O", "--optimization", default=None,
                         help="Optimization level")
     parser.add_argument("--registers", default=None, help="Number of registers")


### PR DESCRIPTION
The compiler accepts `--trace-format=<text|binary|both>` to pick how the
recorded trace is serialized — `.fhetch` text, `.fhex` binary (roughly 4x
smaller and faster to read), or both. The default is unchanged: text.

A program that owns its `argv` could already pass the flag straight through to
`compiler().init()`, and so could `session.init(["--trace-format=binary"])`.
The auto-facade could not: `build_init_argv()` maps an explicit allowlist of
YAML keys to flags, and `tools/nbcc.py` writes that YAML, so a key missing from
either is silently ignored.

Adds `trace_format` to both, so the no-code-change path works:

    nbcc.py --trace-format=binary -- ./my_program

Also documents the flag in the README's capture step and the `trace_format` key
in the auto-facade config reference, and bumps `vendor/niobium-fhetch`.

`test-auto-trace-format-release` covers the whole chain for all three formats
and asserts on the artifacts, not just that the run succeeded — with the
allowlist entry missing the run still succeeds and silently writes text.
Verified to fail, naming expected and actual counts, when that entry is
removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)